### PR TITLE
Go data > Image grid

### DIFF
--- a/App/Containers/PhotoViewerScreen.js
+++ b/App/Containers/PhotoViewerScreen.js
@@ -73,8 +73,7 @@ class PhotoViewerScreen extends React.PureComponent {
 const mapStateToProps = (state) => {
   const items = state.textile && state.textile.images && state.textile.images.items ? state.textile.images.items : []
   const imageData = items.map(item => {
-    const image = item.image.node.image
-    const {width, height, hash} = image
+    const {width, height, hash} = item.image
     return {
       source: { uri: 'file:///image.jpg' },
       hash,

--- a/App/Redux/EventLogging.js
+++ b/App/Redux/EventLogging.js
@@ -15,7 +15,6 @@ const eventLogging = ({ getState }) => next => (action) => {
     if (additionalPayload) {
       payload = {...payload, ...additionalPayload}
     }
-    console.log('ACTION:', action.type, 'PAYLOAD:', payload)
     Analytics.trackEvent(action.type, payload)
     return next(action)
   }

--- a/App/Redux/IpfsNodeRedux.js
+++ b/App/Redux/IpfsNodeRedux.js
@@ -15,7 +15,10 @@ const { Types, Creators } = createActions({
   startNodeFailure: ['error'],
   stopNodeRequest: null,
   stopNodeSuccess: null,
-  stopNodeFailure: ['error']
+  stopNodeFailure: ['error'],
+  getPhotoHashesRequest: null,
+  getPhotoHashesSuccess: ['hashes'],
+  getPhotoHashesFailure: ['error']
 })
 
 export const IpfsNodeTypes = Types
@@ -30,6 +33,11 @@ export const INITIAL_STATE = Immutable({
   },
   gatewayState: {
     state: 'stopped', // | starting | started
+    error: null
+  },
+  photos: {
+    querying: false,
+    hashes: [],
     error: null
   }
 })
@@ -71,6 +79,15 @@ export const nodeStopped = state =>
 export const nodeError = (state, {error}) =>
   state.merge({...state, nodeState: {error: error}})
 
+export const photoHashesRequest = state =>
+  state.merge({...state, photos: {...state.photos, querying: true}})
+
+export const photoHashesSuccess = (state, {hashes}) =>
+  state.merge({...state, photos: {...state.photos, querying: false, hashes}})
+
+export const photoHashesFailure = (state, {error}) =>
+  state.merge({...state, photos: {...state.photos, querying: false, error}})
+
 // Helper so sagas can figure out current items loaded
 // const getItems = state => state.items
 
@@ -91,5 +108,9 @@ export const reducer = createReducer(INITIAL_STATE, {
 
   [Types.STOP_NODE_REQUEST]: nodeStopping,
   [Types.STOP_NODE_SUCCESS]: nodeStopped,
-  [Types.STOP_NODE_FAILURE]: nodeError
+  [Types.STOP_NODE_FAILURE]: nodeError,
+
+  [Types.GET_PHOTO_HASHES_REQUEST]: photoHashesRequest,
+  [Types.GET_PHOTO_HASHES_SUCCESS]: photoHashesSuccess,
+  [Types.GET_PHOTO_HASHES_FAILURE]: photoHashesFailure
 })

--- a/App/Redux/TextileRedux.js
+++ b/App/Redux/TextileRedux.js
@@ -68,13 +68,8 @@ export const handleImageProgress = (state, {data}) => {
 
 export const handleImageUploadComplete = (state, {data}) => {
   const {file} = data
-  const existingItems = state.images.items ? state.images.items : []
-  const items = existingItems.map(item => {
-    if (item.remotePayloadPath === file) {
-      return {...item, state: 'complete'}
-    }
-    return item
-  })
+  // Remove the item from Redux storage
+  const items = state.images.items.filter(item => item.remotePayloadPath !== file)
   return state.merge({ images: { items } })
 }
 

--- a/App/Sagas/StartupSagas.js
+++ b/App/Sagas/StartupSagas.js
@@ -34,4 +34,5 @@ export function * startup () {
 
   yield put(IpfsNodeActions.createNodeRequest(RNFS.DocumentDirectoryPath))
   yield put(IpfsNodeActions.startNodeRequest())
+  yield put(IpfsNodeActions.getPhotoHashesRequest())
 }

--- a/App/Sagas/TextileSagas.js
+++ b/App/Sagas/TextileSagas.js
@@ -95,6 +95,15 @@ export function * startNode () {
   }
 }
 
+export function * getPhotoHashes () {
+  try {
+    const photoData = yield call(IPFS.getPhotos, null, 100000)
+    yield put(IpfsNodeActions.getPhotoHashesSuccess(photoData))
+  } catch (error) {
+    yield put(IpfsNodeActions.getPhotoHashesFailure(error))
+  }
+}
+
 export function * pairNewDevice (action) {
   const { pubKey } = action
   try {
@@ -116,10 +125,10 @@ export function * photosTask (action) {
     yield call(IPFS.startNode)
     const photos = yield call(queryPhotos)
     for (const photo of photos) {
-      const multipartData = yield call(IPFS.addImageAtPath, photo.node.image.path, photo.node.image.thumbPath)
-      yield call(RNFS.unlink, photo.node.image.path)
-      yield call(RNFS.unlink, photo.node.image.thumbPath)
-      photo.node.image['hash'] = multipartData.boundary
+      const multipartData = yield call(IPFS.addImageAtPath, photo.path, photo.thumbPath)
+      yield call(RNFS.unlink, photo.path)
+      yield call(RNFS.unlink, photo.thumbPath)
+      photo['hash'] = multipartData.boundary
       yield put(TextileActions.imageAdded(photo, multipartData.payloadPath))
       yield call(
         UploadTask.uploadFile,

--- a/App/Sagas/index.js
+++ b/App/Sagas/index.js
@@ -18,6 +18,7 @@ import {
   startGateway,
   startNode,
   pairNewDevice,
+  getPhotoHashes,
   photosTask,
   removePayloadFile
 } from './TextileSagas'
@@ -39,6 +40,9 @@ export default function * root () {
     takeLatest(IpfsNodeTypes.START_GATEWAY_REQUEST, startGateway),
     takeLatest(IpfsNodeTypes.START_NODE_REQUEST, startNode),
     takeLatest(TextileTypes.PAIR_NEW_DEVICE, pairNewDevice),
+
+    takeEvery(IpfsNodeTypes.GET_PHOTO_HASHES_REQUEST, getPhotoHashes),
+    takeEvery(TextileTypes.IMAGE_ADDED, getPhotoHashes),
 
     takeEvery(TextileTypes.APP_STATE_CHANGE, photosTask),
     takeEvery(TextileTypes.LOCATION_UPDATE, photosTask),

--- a/TextileIPFSNativeModule.js
+++ b/TextileIPFSNativeModule.js
@@ -30,13 +30,11 @@ export default {
   },
 
   addImageAtPath: async function (path: string, thumbPath: string): MultipartData {
-    console.log('ADDING IMAGE:', path, thumbPath)
     const multipartData = await TextileIPFS.addImageAtPath(path, thumbPath)
-    console.log('ADDED IMAGE:', multipartData)
     return multipartData
   },
 
-  getPhotos: async function (offset: string, limit: number): string {
+  getPhotos: async function (offset: ?string, limit: number): string {
     const result = await TextileIPFS.getPhotos(offset, limit)
     return result
   },

--- a/ios/NativeModules/TextileIPFS.m
+++ b/ios/NativeModules/TextileIPFS.m
@@ -93,8 +93,11 @@ RCT_EXPORT_METHOD(addImageAtPath:(NSString *)path thumbPath:(NSString *)thumbPat
 RCT_EXPORT_METHOD(getPhotos:(NSString *)offset limit:(int)limit resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   NSError *error;
   NSString *hashesString = [self _getPhotosFromOffset:offset withLimit:limit error:&error];
-  if (hashesString) {
-    resolve(hashesString);
+  NSData *data = [hashesString dataUsingEncoding:NSUTF8StringEncoding];
+  id json = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
+  NSArray *hashes = [json objectForKey:@"hashes"];
+  if (hashes) {
+    resolve(hashes);
   } else {
     reject(@(error.code).stringValue, error.localizedDescription, error);
   }


### PR DESCRIPTION
Query image list from go layer, augment with redux state for pending/processing images. This makes the go layer the authoritative source for the list of images. Persistent redux storage is only used to store an image's pending, processing, or error states. Once the image is successfully added remotely, the record is removed from redux.

This should set us up to use the grid, or some of it's code, for the shared thread UI.