### PR TITLE
Temp image viewer fix

### DIFF
--- a/App/Containers/PhotoViewerScreen.js
+++ b/App/Containers/PhotoViewerScreen.js
@@ -41,7 +41,7 @@ class PhotoViewerScreen extends React.PureComponent {
   }
 
   renderImage(image) {
-    const imageData = IPFS.syncGetPhotoData(image.image.hash + '/photo')
+    const imageData = IPFS.syncGetPhotoData(image.image.hash + '/thumb')
     return (
       <Image
         source={{uri: 'data:image/jpeg;base64,' + imageData}}
@@ -71,13 +71,12 @@ class PhotoViewerScreen extends React.PureComponent {
 }
 
 const mapStateToProps = (state) => {
-  const items = state.textile && state.textile.images && state.textile.images.items ? state.textile.images.items : []
-  const imageData = items.map(item => {
-    const {width, height, hash} = item.image
+  const hashes = state.ipfs.photos.hashes
+  const imageData = hashes.map(hash => {
     return {
       source: { uri: 'file:///image.jpg' },
       hash,
-      dimensions: { width: width, height: height }
+      dimensions: { width: 100, height: 100 }
     }
   })
   return {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-native-elements": "^1.0.0-beta4",
     "react-native-fs": "^2.9.12",
     "react-native-i18n": "1.0.0",
-    "react-native-image-gallery": "^2.1.5",
+    "react-native-image-gallery": "git+https://git@github.com/textileio/react-native-image-gallery.git",
     "react-native-image-resizer": "^1.0.0",
     "react-native-keyboard-aware-scroll-view": "^0.5.0",
     "react-native-progress": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7874,9 +7874,9 @@ react-native-i18n@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/react-native-i18n/-/react-native-i18n-1.0.0.tgz#0c407d9ebb846aae1aa5e05de6503008553f02fd"
 
-react-native-image-gallery@^2.1.5:
+"react-native-image-gallery@git+https://git@github.com/textileio/react-native-image-gallery.git":
   version "2.1.5"
-  resolved "https://registry.yarnpkg.com/react-native-image-gallery/-/react-native-image-gallery-2.1.5.tgz#f524b92ef7284d30ffbbd63f93019e0647e23229"
+  resolved "git+https://git@github.com/textileio/react-native-image-gallery.git#103f8fc240e852aa1dbad176495dc3f24e445d37"
   dependencies:
     prop-types "^15.6.0"
     react-mixin "^3.0.5"


### PR DESCRIPTION
Point at fork of the image viewer lib to get a bug fix, hack in a working viewer for now. Loading thumb image data to cut down on memory usage until our URI based approach is ready. 

Be sure to `yarn install` to get the image view lib fork in there.