### PR TITLE
Refactor out non-UI event listeners, tabbed UI

### DIFF
--- a/App/Containers/OnboardingCheck.js
+++ b/App/Containers/OnboardingCheck.js
@@ -7,7 +7,7 @@ class OnboardingCheck extends Component {
     super(props)
     // This will switch to the App screen or Auth screen and this loading
     // screen will be unmounted and thrown away.
-    this.props.navigation.navigate(this.props.onboarded ? 'PhotosNavigation' : 'OnboardingNavigation')
+    this.props.navigation.navigate(this.props.onboarded ? 'TextileManager' : 'OnboardingNavigation')
   }
   render () {
     return (

--- a/App/Containers/TextileManager.js
+++ b/App/Containers/TextileManager.js
@@ -1,0 +1,76 @@
+// @flow
+import React from 'react'
+import {
+  Linking,
+  Platform,
+  AppState
+} from 'react-native'
+import { connect } from 'react-redux'
+import BackgroundTask from 'react-native-background-task'
+import TextileActions from '../Redux/TextileRedux'
+import UploadTask from '../../UploadTaskNativeModule'
+import PhotosNavigation from '../Navigation/PhotosNavigation'
+
+class TextileManager extends React.PureComponent {
+  constructor () {
+    super()
+    this.setup()
+  }
+
+  // TODO: This logic should be moved deeper into the stack
+  _handleOpenURLEvent (event) {
+    this._handleOpenURL(event.url)
+  }
+  // TODO: This logic should be moved deeper into the stack
+  _handleOpenURL (url) {
+    const data = url.replace(/.*?:\/\//g, '')
+    this.props.navigation.navigate('PairingView', {data: data})
+  }
+
+  componentDidMount () {
+    BackgroundTask.schedule()
+    // TODO: This logic should be moved deeper into the stack
+    if (Platform.OS === 'android') {
+      // TODO: Android deep linking isn't setup in the Java native layer
+      Linking.getInitialURL().then(url => {
+        this._handleOpenURL(url)
+      })
+    } else {
+      Linking.addEventListener('url', this._handleOpenURLEvent.bind(this))
+    }
+  }
+
+  componentWillUnmount () {
+    AppState.removeEventListener('change', this.props.appStateChange)
+    this.progressSubscription.remove()
+    this.completionSubscription.remove()
+    this.errorSubscription.remove()
+  }
+
+  async setup () {
+    // await PushNotificationIOS.requestPermissions()
+    AppState.addEventListener('change', (event) => this.props.appStateChange(event))
+    navigator.geolocation.watchPosition(() => this.props.locationUpdate(), null, { useSignificantChanges: true })
+    this.progressSubscription = UploadTask.uploadTaskEmitter.addListener('UploadTaskProgress', (event) => this.props.uploadProgress(event))
+    this.completionSubscription = UploadTask.uploadTaskEmitter.addListener('UploadTaskComplete', (event) => this.props.uploadComplete(event))
+    this.errorSubscription = UploadTask.uploadTaskEmitter.addListener('UploadTaskError', (event) => this.props.uploadError(event))
+  }
+
+  render () {
+    return (
+      <PhotosNavigation />
+    )
+  }
+}
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    appStateChange: event => { dispatch(TextileActions.appStateChange(event)) },
+    locationUpdate: () => { dispatch(TextileActions.locationUpdate()) },
+    uploadComplete: event => { dispatch(TextileActions.imageUploadComplete(event)) },
+    uploadProgress: event => { dispatch(TextileActions.imageUploadProgress(event)) },
+    uploadError: event => { dispatch(TextileActions.imageUploadError(event)) }
+  }
+}
+
+export default connect(null, mapDispatchToProps)(TextileManager)

--- a/App/Containers/TextilePhotos.js
+++ b/App/Containers/TextilePhotos.js
@@ -5,20 +5,10 @@ import {
   Image,
   Text,
   FlatList,
-  TouchableOpacity,
-  Linking,
-  Platform,
-  AppState,
-  PushNotificationIOS
+  TouchableOpacity
 } from 'react-native'
-import Immutable from 'seamless-immutable'
-import Icon from 'react-native-vector-icons/Ionicons'
 import Evilicon from 'react-native-vector-icons/EvilIcons'
 import { connect } from 'react-redux'
-import BackgroundTask from 'react-native-background-task'
-import TextileActions from '../Redux/TextileRedux'
-import UploadTask from '../../UploadTaskNativeModule'
-import HeaderButtons from 'react-navigation-header-buttons'
 import * as Progress from 'react-native-progress'
 import Toast from 'react-native-easy-toast'
 import { Colors } from '../Themes'
@@ -28,73 +18,13 @@ import IPFS from '../../TextileIPFSNativeModule'
 import styles, {PRODUCT_ITEM_HEIGHT, PRODUCT_ITEM_MARGIN, numColumns} from './Styles/TextilePhotosStyle'
 
 class TextilePhotos extends React.PureComponent {
-
-  constructor() {
-    super()
-    this.setup()
-  }
-
   static navigationOptions = ({ navigation }) => {
     const params = navigation.state.params || {}
     return {
       headerTitle: (
         <Image source={require('../Images/TextileHeader.png')} />
-      ),
-      headerRight: (
-        <HeaderButtons IconComponent={Icon} iconSize={23} color='white'>
-          <HeaderButtons.Item title='more' iconName='ios-more' onPress={params.openLogs} />
-        </HeaderButtons>
       )
     }
-  }
-
-  componentWillMount () {
-    this.props.navigation.setParams({
-      openLogs: this.openLogs.bind(this)
-    })
-  }
-
-  openLogs = () => {
-    this.props.navigation.navigate('InfoView')
-  }
-
-  // TODO: This logic should be moved deeper into the stack
-  _handleOpenURLEvent (event) {
-    this._handleOpenURL(event.url)
-  }
-  // TODO: This logic should be moved deeper into the stack
-  _handleOpenURL (url) {
-    const data = url.replace(/.*?:\/\//g, '')
-    this.props.navigation.navigate('PairingView', {data: data})
-  }
-
-  componentDidMount () {
-    BackgroundTask.schedule()
-    // TODO: This logic should be moved deeper into the stack
-    if (Platform.OS === 'android') {
-      // TODO: Android deep linking isn't setup in the Java native layer
-      Linking.getInitialURL().then(url => {
-        this._handleOpenURL(url)
-      })
-    } else {
-      Linking.addEventListener('url', this._handleOpenURLEvent.bind(this))
-    }
-  }
-
-  componentWillUnmount () {
-    AppState.removeEventListener('change', this.props.appStateChange)
-    this.progressSubscription.remove()
-    this.completionSubscription.remove()
-    this.errorSubscription.remove()
-  }
-
-  async setup () {
-    // await PushNotificationIOS.requestPermissions()
-    AppState.addEventListener('change', (event) => this.props.appStateChange(event))
-    navigator.geolocation.watchPosition(() => this.props.locationUpdate(), null, { useSignificantChanges: true })
-    this.progressSubscription = UploadTask.uploadTaskEmitter.addListener('UploadTaskProgress', (event) => this.props.uploadProgress(event))
-    this.completionSubscription = UploadTask.uploadTaskEmitter.addListener('UploadTaskComplete', (event) => this.props.uploadComplete(event))
-    this.errorSubscription = UploadTask.uploadTaskEmitter.addListener('UploadTaskError', (event) => this.props.uploadError(event))
   }
 
   /* ***********************************************************
@@ -254,13 +184,7 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = (dispatch) => {
-  return {
-    appStateChange: event => { dispatch(TextileActions.appStateChange(event)) },
-    locationUpdate: () => { dispatch(TextileActions.locationUpdate()) },
-    uploadComplete: event => { dispatch(TextileActions.imageUploadComplete(event)) },
-    uploadProgress: event => { dispatch(TextileActions.imageUploadProgress(event)) },
-    uploadError: event => { dispatch(TextileActions.imageUploadError(event)) }
-  }
+  return {}
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(TextilePhotos)

--- a/App/Navigation/AppNavigation.js
+++ b/App/Navigation/AppNavigation.js
@@ -1,14 +1,14 @@
 /* @flow */
 import { SwitchNavigator } from 'react-navigation'
 import OnboardingNavigation from './OnboardingNavigation'
-import PhotosNavigation from './PhotosNavigation'
+import TextileManager from '../Containers/TextileManager'
 import OnboardingCheck from '../Containers/OnboardingCheck'
 
 const PrimaryNav = SwitchNavigator(
   {
     OnboardingCheck: OnboardingCheck,
     OnboardingNavigation: OnboardingNavigation,
-    PhotosNavigation: PhotosNavigation
+    TextileManager: TextileManager
   },
   {
     initialRouteName: 'OnboardingCheck'

--- a/App/Navigation/PhotosNavigation.js
+++ b/App/Navigation/PhotosNavigation.js
@@ -1,11 +1,13 @@
 /* @flow */
 import React from 'react'
 import DismissableStackNavigator from '../Components/DismissableStackNavigator'
-import { StackNavigator } from 'react-navigation'
+import { StackNavigator, TabNavigator, TabBarBottom } from 'react-navigation'
+import Ionicons from 'react-native-vector-icons/Ionicons'
 import TextilePhotos from '../Containers/TextilePhotos'
 import InfoView from '../Containers/InfoView'
 import PairingView from '../Containers/PairingView'
 import PhotoViewerScreen from '../Containers/PhotoViewerScreen'
+import Colors from '../Themes/Colors'
 // import Notifications from '../Containers/Notifications'
 // import Image from 'react-native'
 
@@ -14,21 +16,92 @@ import PhotoViewerScreen from '../Containers/PhotoViewerScreen'
 import styles, {headerTintColor} from './Styles/NavigationStyles'
 
 // Manifest of possible screens
-const PrimaryNav = StackNavigator(
+
+const PhotosNav = StackNavigator(
   {
-    TextilePhotos: TextilePhotos,
-    InfoView: InfoView,
-    PairingView: PairingView
+    TextilePhotos: TextilePhotos
   },
   {
     // Default config for all screens
     headerMode: 'float',
-    initialRouteName: 'TextilePhotos',
     navigationOptions: {
       headerStyle: styles.header,
       headerTitleStyle: styles.headerTitle,
       headerTintColor: headerTintColor
     }
+  }
+)
+
+const SharedPhotosNav = StackNavigator(
+  {
+    SharedPhotos: TextilePhotos
+  },
+  {
+    // Default config for all screens
+    headerMode: 'float',
+    navigationOptions: {
+      headerStyle: styles.header,
+      headerTitleStyle: styles.headerTitle,
+      headerTintColor: headerTintColor
+    }
+  }
+)
+
+const InfoNav = StackNavigator(
+  {
+    InfoView: InfoView
+  },
+  {
+    // Default config for all screens
+    headerMode: 'float',
+    navigationOptions: {
+      headerStyle: styles.header,
+      headerTitleStyle: styles.headerTitle,
+      headerTintColor: headerTintColor
+    }
+  }
+)
+
+const TabNav = TabNavigator(
+  {
+    PhotosNav: { screen: PhotosNav },
+    // SharedPhotosNav: { screen: SharedPhotosNav },
+    InfoNav: { screen: InfoNav }
+  },
+  {
+    navigationOptions: ({ navigation }) => {
+      const {routeName} = navigation.state
+      let title
+      if (routeName === 'PhotosNav') {
+        title = 'Library'
+      } else if (routeName === 'SharedPhotosNav') {
+        title = 'Shared'
+      } else if (routeName === 'InfoNav') {
+        title = 'Support'
+      }
+      return {
+        tabBarIcon: ({focused, tintColor}) => {
+          let iconName
+          if (routeName === 'PhotosNav') {
+            iconName = `ios-photos${focused ? '' : '-outline'}`
+          } else if (routeName === 'SharedPhotosNav') {
+            iconName = `ios-globe${focused ? '' : '-outline'}`
+          } else if (routeName === 'InfoNav') {
+            iconName = `ios-information-circle${focused ? '' : '-outline'}`
+          }
+          return <Ionicons name={iconName} size={25} color={tintColor}/>
+        },
+        title: title
+      }
+    },
+    tabBarOptions: {
+      activeTintColor: Colors.brandRed,
+      inactiveTintColor: 'gray'
+    },
+    tabBarComponent: TabBarBottom,
+    tabBarPosition: 'bottom',
+    animationEnabled: false,
+    swipeEnabled: false,
   }
 )
 
@@ -43,14 +116,31 @@ const PhotoViewerStack = DismissableStackNavigator(
   }
 )
 
+const PairingStackNav = DismissableStackNavigator(
+  {
+    Pairing: PairingView
+  },
+  {
+    headerMode: 'float',
+    navigationOptions: {
+      headerStyle: styles.header,
+      headerTitleStyle: styles.headerTitle,
+      headerTintColor: headerTintColor
+    }
+  }
+)
+
 const RootStack = StackNavigator(
   {
     PrimaryNav: {
-      screen: PrimaryNav,
+      screen: TabNav
     },
     PhotoViewer: {
-      screen: PhotoViewerStack,
+      screen: PhotoViewerStack
     },
+    PairingView: {
+      screen: PairingStackNav
+    }
   },
   {
     mode: 'modal',


### PR DESCRIPTION
We have a bunch of event listeners that are used to trigger photo queries and update state of photo data. They were all created as part of `TextilePhotos.js`, which is really just the UI for viewing the photo grid. This isn't good design, and it makes the photo grid impossible to re-use. 

This PR does two things:

1. Move all event listeners and redux triggers to a wrapper component, keeping `TextilePhotos.js` more general use and more reusable.
2. Create a tabbed interface for now that we can plug the first cut of shared photos into. It will look something like:
<img width="504" alt="screen shot 2018-04-30 at 15 24 32" src="https://user-images.githubusercontent.com/528969/39449943-2b7b6b8c-4c8f-11e8-903f-8d9a3024a448.png">
That isn't the end design or anything, just a place to start for early testers.
