### PR TITLE
Fix Release Build Node Start

### DIFF
--- a/App/Containers/TextileManager.js
+++ b/App/Containers/TextileManager.js
@@ -32,6 +32,7 @@ class TextileManager extends React.PureComponent {
   }
 
   componentDidMount () {
+    this.props.appStateChange(this.props.currentAppState, AppState.currentState)
     BackgroundTask.schedule()
     // TODO: This logic should be moved deeper into the stack
     if (Platform.OS === 'android') {

--- a/App/Redux/IpfsNodeRedux.js
+++ b/App/Redux/IpfsNodeRedux.js
@@ -28,7 +28,7 @@ export default Creators
 
 export const INITIAL_STATE = Immutable({
   locked: false,
-  appState: 'unknown',
+  appState: null,
   nodeState: {
     state: 'undefined', // | creating | stopped | starting | started | stopping
     error: null

--- a/App/Sagas/StartupSagas.js
+++ b/App/Sagas/StartupSagas.js
@@ -35,6 +35,6 @@ export function * startup () {
 
   // Dispatch actions you want on STARTUP
   // yield put(IpfsNodeActions.createNodeRequest(RNFS.DocumentDirectoryPath))
-  const previousState = yield select(IpfsNodeSelectors.appState)
-  yield put(IpfsNodeActions.appStateChange(previousState, AppState.currentState))
+  // const previousState = yield select(IpfsNodeSelectors.appState)
+  // yield put(IpfsNodeActions.appStateChange(previousState, AppState.currentState))
 }

--- a/App/Sagas/TextileSagas.js
+++ b/App/Sagas/TextileSagas.js
@@ -86,15 +86,23 @@ export function * toggleBackgroundTimer ({value}) {
 }
 
 export function * handleNewAppState ({previousState, newState}) {
-  if (previousState.match(/unknown|background/) && newState === 'background') {
-    console.tron.logImportant('launched into background')
-    yield * triggerCreateNode()
-  } else if (previousState.match(/unknown|inactive|background/) && newState === 'active') {
-    console.tron.logImportant('app transitioned to foreground')
-    yield * triggerCreateNode()
-  } else if (previousState.match(/inactive|active/) && newState === 'background') {
-    console.tron.logImportant('app transitioned to background')
-    yield * triggerStopNode()
+  // TODO: HACK alert
+  if (!previousState) {
+    if (newState.match(/unknown|active/)) {
+      console.tron.logImportant('app transitioned to foreground (cold launch)')
+      yield * triggerCreateNode()
+    }
+  } else {
+    if (previousState.match(/unknown|background/) && newState === 'background') {
+      console.tron.logImportant('launched into background')
+      yield * triggerCreateNode()
+    } else if (previousState.match(/unknown|inactive|background/) && newState === 'active') {
+      console.tron.logImportant('app transitioned to foreground')
+      yield * triggerCreateNode()
+    } else if (previousState.match(/inactive|active/) && newState === 'background') {
+      console.tron.logImportant('app transitioned to background')
+      yield * triggerStopNode()
+    }
   }
 }
 

--- a/App/Sagas/index.js
+++ b/App/Sagas/index.js
@@ -63,7 +63,7 @@ export default function * root () {
     // takeEvery(StartupTypes.STARTUP, triggerCreateNode),
     // takeEvery(TextileTypes.LOCATION_UPDATE, triggerCreateNode),
     // takeEvery(TextileTypes.BACKGROUND_TASK, triggerCreateNode),
-    takeEvery(TextileTypes.ONBOARDED_SUCCESS, triggerCreateNode),
+    // takeEvery(TextileTypes.ONBOARDED_SUCCESS, triggerCreateNode),
 
     // Actions that trigger stopping the node
     // takeEvery(action => action.type === IpfsNodeTypes.APP_STATE_CHANGE && action.newState === 'background', triggerStopNode),


### PR DESCRIPTION
Hack to detect when the app enters the foreground from cold start in a release build. I don't love this as a long term solution, but it should work for now. 

The key to the hack is that I found a particular pattern of behavior from `AppState` api when the app is launched into the foreground from a terminated state. We map this specific behavior to a 'foreground' event.

Let's be sure to test this on android as well, i've only tried iOS so far.