### PR TITLE
Give asset lib file copy and explicit JPG extesion

### DIFF
--- a/App/Services/PhotoUtils.js
+++ b/App/Services/PhotoUtils.js
@@ -50,7 +50,7 @@ export async function queryPhotos () {
           while (match = regex.exec(photo.uri)) {
             params[match[1]] = match[2]
           }
-          const path = fullDir + params.id + '.' + params.ext
+          const path = fullDir + params.id + '.' + 'JPG'
           await RNFS.copyAssetsFileIOS(photo.uri, path, 0, 0)
           photo['path'] = path
           const thumbPath = await resizeImage(photo.path, thumbRelativeDir)


### PR DESCRIPTION
Big one. This fixes the crash we were seeing when adding images from camera roll on a real device.