### PR TITLE
Node status viz

### DIFF
--- a/App/Containers/Styles/TextilePhotosStyle.js
+++ b/App/Containers/Styles/TextilePhotosStyle.js
@@ -1,0 +1,20 @@
+import { StyleSheet } from 'react-native'
+import { ApplicationStyles, Metrics, Colors } from '../../Themes'
+
+export default StyleSheet.create({
+  ...ApplicationStyles.screen,
+  bottomOverlay: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    position: 'absolute',
+    width: '100%',
+    bottom: 0,
+    height: 20,
+    paddingHorizontal: 16,
+    backgroundColor: 'rgba(0,0,0,0.5)'
+  },
+  overlayText: {
+    color: 'white',
+    fontFamily: 'Biotif-Regular'
+  }
+})

--- a/App/Containers/Styles/TextilePhotosStyle.js
+++ b/App/Containers/Styles/TextilePhotosStyle.js
@@ -3,6 +3,9 @@ import { ApplicationStyles, Metrics, Colors } from '../../Themes'
 
 export default StyleSheet.create({
   ...ApplicationStyles.screen,
+  container: {
+    flex: 1
+  },
   bottomOverlay: {
     justifyContent: 'center',
     alignItems: 'center',

--- a/App/Containers/TextilePhotos.js
+++ b/App/Containers/TextilePhotos.js
@@ -1,11 +1,27 @@
 // @flow
 import React from 'react'
+import {Image, TouchableWithoutFeedback} from 'react-native'
 import PhotoGrid from '../Components/PhotoGrid'
 import { connect } from 'react-redux'
+import TextileActions from '../Redux/TextileRedux'
 import IpfsNodeActions from '../Redux/IpfsNodeRedux'
 import UIActions from '../Redux/UIRedux'
+import styles from '../Navigation/Styles/NavigationStyles'
 
 class TextilePhotos extends React.PureComponent {
+  static navigationOptions = ({ navigation }) => {
+    const { params } = navigation.state
+    return {
+      headerTitle: <TouchableWithoutFeedback delayLongPress={3000} onLongPress={params.toggleVerboseUi}>
+        <Image style={styles.headerTitleImage} source={require('../Images/TextileHeader.png')} />
+      </TouchableWithoutFeedback>
+    }
+  }
+
+  componentDidMount () {
+    this.props.navigation.setParams({ toggleVerboseUi: this.props.toggleVerboseUi })
+  }
+
   onSelect = (row) => {
     return () => {
       this.props.viewPhoto(row.index, this.props.thread)
@@ -64,7 +80,8 @@ const mapStateToProps = (state, ownProps) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     viewPhoto: (index, thread) => { dispatch(UIActions.viewPhotoRequest(index, thread)) },
-    refresh: thread => { dispatch(IpfsNodeActions.getPhotoHashesRequest(thread)) }
+    refresh: thread => { dispatch(IpfsNodeActions.getPhotoHashesRequest(thread)) },
+    toggleVerboseUi: () => { dispatch(TextileActions.toggleVerboseUi()) }
   }
 }
 

--- a/App/Containers/TextilePhotos.js
+++ b/App/Containers/TextilePhotos.js
@@ -35,7 +35,7 @@ class TextilePhotos extends React.PureComponent {
 
   render () {
     return (
-      <View style={{flex: 1}}>
+      <View style={style.container}>
         <PhotoGrid
           items={this.props.items}
           onSelect={this.onSelect}

--- a/App/Containers/TextilePhotos.js
+++ b/App/Containers/TextilePhotos.js
@@ -1,19 +1,20 @@
 // @flow
 import React from 'react'
-import {Image, TouchableWithoutFeedback} from 'react-native'
+import {View, Text, Image, TouchableWithoutFeedback} from 'react-native'
 import PhotoGrid from '../Components/PhotoGrid'
 import { connect } from 'react-redux'
 import TextileActions from '../Redux/TextileRedux'
 import IpfsNodeActions from '../Redux/IpfsNodeRedux'
 import UIActions from '../Redux/UIRedux'
-import styles from '../Navigation/Styles/NavigationStyles'
+import style from './Styles/TextilePhotosStyle'
+import navStyles from '../Navigation/Styles/NavigationStyles'
 
 class TextilePhotos extends React.PureComponent {
   static navigationOptions = ({ navigation }) => {
     const { params } = navigation.state
     return {
       headerTitle: <TouchableWithoutFeedback delayLongPress={3000} onLongPress={params.toggleVerboseUi}>
-        <Image style={styles.headerTitleImage} source={require('../Images/TextileHeader.png')} />
+        <Image style={navStyles.headerTitleImage} source={require('../Images/TextileHeader.png')} />
       </TouchableWithoutFeedback>
     }
   }
@@ -34,15 +35,21 @@ class TextilePhotos extends React.PureComponent {
 
   render () {
     return (
-      <PhotoGrid
-        items={this.props.items}
-        loadingText={this.props.loadingText}
-        onSelect={this.onSelect}
-        onRefresh={this.onRefresh.bind(this)}
-        refreshing={this.props.refreshing}
-        placeholderText={this.props.placeholderText}
-        displayImages={this.props.displayImages}
-      />
+      <View style={{flex: 1}}>
+        <PhotoGrid
+          items={this.props.items}
+          onSelect={this.onSelect}
+          onRefresh={this.onRefresh.bind(this)}
+          refreshing={this.props.refreshing}
+          placeholderText={this.props.placeholderText}
+          displayImages={this.props.displayImages}
+        />
+        {this.props.verboseUi &&
+          <View style={style.bottomOverlay} >
+            <Text style={style.overlayText}>{this.props.nodeStatus}</Text>
+          </View>
+        }
+      </View>
     )
   }
 }
@@ -73,7 +80,9 @@ const mapStateToProps = (state, ownProps) => {
     items: updatedItems,
     refreshing: state.ipfs.threads[thread].querying,
     displayImages: state.ipfs.nodeState.state === 'started',
-    placeholderText
+    placeholderText,
+    nodeStatus,
+    verboseUi: state.textile.preferences.verboseUi
   }
 }
 

--- a/App/Navigation/PhotosNavigation.js
+++ b/App/Navigation/PhotosNavigation.js
@@ -20,10 +20,7 @@ import styles, {headerTintColor} from './Styles/NavigationStyles'
 const PhotosNav = StackNavigator(
   {
     TextilePhotos: {
-      screen: TextilePhotos,
-      navigationOptions: {
-        headerTitle: <Image style={styles.headerTitleImage} source={require('../Images/TextileHeader.png')} />
-      }
+      screen: TextilePhotos
     }
   },
   {

--- a/App/Redux/TextileRedux.js
+++ b/App/Redux/TextileRedux.js
@@ -154,6 +154,8 @@ export const pairNewDeviceError = (state, {pubKey}) => {
 export const reducer = createReducer(INITIAL_STATE, {
   [Types.ONBOARDED_SUCCESS]: onboardedSuccess,
 
+  [Types.TOGGLE_VERBOSE_UI]: toggleVerboseUi,
+
   [Types.IMAGE_ADDED]: handleImageAdded,
 
   [Types.IMAGE_UPLOAD_PROGRESS]: handleImageProgress,

--- a/App/Redux/TextileRedux.js
+++ b/App/Redux/TextileRedux.js
@@ -6,6 +6,8 @@ import Immutable from 'seamless-immutable'
 const { Types, Creators } = createActions({
   onboardedSuccess: null,
 
+  toggleVerboseUi: null,
+
   locationUpdate: null,
   backgroundTask: null,
 
@@ -30,6 +32,9 @@ export default Creators
 
 export const INITIAL_STATE = Immutable({
   onboarded: false,
+  preferences: {
+    verboseUi: false
+  },
   images: {
     error: false,
     loading: false,
@@ -53,6 +58,9 @@ export const TextileSelectors = {
 export const onboardedSuccess = state => {
   return state.merge({ onboarded: true })
 }
+
+export const toggleVerboseUi = state =>
+  state.merge({ preferences: { ...state.preferences, verboseUi: !state.preferences.verboseUi } })
 
 export const handleImageAdded = (state, {thread, hash, remotePayloadPath}) => {
   const items = [{ thread, hash, remotePayloadPath, state: 'pending' }, ...state.images.items]


### PR DESCRIPTION
This adds a 'preferences' key to our persistent Redux. Right now the only key in there is `verboseUi`. When `verboseUi` is `true`, we can chose to render more data into the UI. For now, I display the node state at the bottom of the photo grid so you can see it even when there are photos in the grid.