### PR TITLE
Preferences persistence migration

### DIFF
--- a/App/Config/ReduxPersist.js
+++ b/App/Config/ReduxPersist.js
@@ -4,7 +4,7 @@ import { createMigrate } from 'redux-persist'
 
 const migrations = {
   0: (state) => {
-    // migration clear out device state
+    // Migration to add user preferences with option for verboseUi
     return {
       ...state,
       textile: state.textile.merge({

--- a/App/Config/ReduxPersist.js
+++ b/App/Config/ReduxPersist.js
@@ -1,5 +1,21 @@
 import immutablePersistenceTransform from '../Services/ImmutablePersistenceTransform'
 import { AsyncStorage } from 'react-native'
+import { createMigrate } from 'redux-persist'
+
+const migrations = {
+  0: (state) => {
+    // migration clear out device state
+    return {
+      ...state,
+      textile: {
+        ...state.textile,
+        preferences: {
+          verboseUi: false
+        }
+      }
+    }
+  }
+}
 
 // More info here:  https://shift.infinite.red/shipping-persistant-reducers-7341691232b1
 const REDUX_PERSIST = {
@@ -7,7 +23,9 @@ const REDUX_PERSIST = {
   reducerVersion: '1.0',
   storeConfig: {
     key: 'primary',
+    version: 0,
     storage: AsyncStorage,
+    migrate: createMigrate(migrations, { debug: false }),
     // Reducer keys that you do NOT want stored to persistence here.
     blacklist: ['nav', 'ipfs', 'auth', 'ui'],
     // Optionally, just specify the keys you DO want stored to persistence.

--- a/App/Config/ReduxPersist.js
+++ b/App/Config/ReduxPersist.js
@@ -7,12 +7,11 @@ const migrations = {
     // migration clear out device state
     return {
       ...state,
-      textile: {
-        ...state.textile,
+      textile: state.textile.merge({
         preferences: {
           verboseUi: false
         }
-      }
+      })
     }
   }
 }


### PR DESCRIPTION
Turns out the behavior of redux-persist is to overwrite your initial state (and any changes/additions you make to it in, for example, `TextileRedux.js`) with whatever was persisted previously. This explains why the `textile.preferences.verboseUi` key wasn't present when updating to the version of the app that added it to `TextileRedux.js`... The previously persisted data didn't contain that key.

The answer: Migration.

This looks like a tiny change, but I dug deep into understanding how redux, redux-persist, seamless-immutable and migrations all work together. Pretty tricky stuff, but now that I understand it, we're gold for migrating persisted data in the future.

