### PR TITLE
Removes mid-state which seemed to generate an extra image request

### DIFF
--- a/App/Components/ProgressiveImage.js
+++ b/App/Components/ProgressiveImage.js
@@ -38,6 +38,7 @@ export default class ProgressiveImage extends React.Component {
       style={[{position: 'absolute', top: 0, bottom: 0, left: 0, right: 0}, this.props.style]}
       resizeMode={this.props.resizeMode}
       capInsets={this.props.capInsets}
+      opacity={this.state.loaded ? 0 : 1} // make it transparent if full available
       onLoad={this._onPreview.bind(this)}
     />)
   }
@@ -49,21 +50,14 @@ export default class ProgressiveImage extends React.Component {
       style={[{backgroundColor: 'transparent', position: 'absolute', top: 0, bottom: 0, left: 0, right: 0}, this.props.style]}
       resizeMode={this.props.resizeMode}
       capInsets={this.props.capInsets}
-      opacity={this.state.loaded ? 1 : 0}
+      opacity={this.state.loaded ? 1 : 0} // keep it transparent until available
       onLoad={this._onLoaded.bind(this)}
     />)
   }
 
   render () {
-    if (this.state.loaded || this.props.previewPath === undefined) {
+    if (this.state.preview || this.props.previewPath === undefined) {
       // if full res is available, don't bother showing thumb in stack
-      return (
-        <View style={this.props.style}>
-          {this.renderPhoto()}
-        </View>
-      )
-    } else if (this.state.preview) {
-      // if thumb is available, start loading the full res
       return (
         <View style={this.props.style}>
           {this.renderPreview()}


### PR DESCRIPTION
Just uses an opacity switch to show the full res only when finished loading successfully 

fixes #164 