### PR TITLE
Always clean up photo path

### DIFF
--- a/App/Sagas/TextileSagas.ts
+++ b/App/Sagas/TextileSagas.ts
@@ -278,6 +278,7 @@ export function * photosTask() {
         addedPhotosData.push({ uri, addResult, blockId })
       } catch (error) {
         yield put(CameraRollActions.untrackPhoto(uri))
+      } finally {
         const exists: boolean = yield call(RNFS.exists, photoPath)
         if (exists) {
           yield call(RNFS.unlink, photoPath)


### PR DESCRIPTION
We need to always delete the photo after it is added to textile or fails to be added.