### PR TITLE
Reprocess lost spinners

### DIFF
--- a/App/Redux/UploadingImagesRedux.ts
+++ b/App/Redux/UploadingImagesRedux.ts
@@ -57,6 +57,15 @@ export const UploadingImagesSelectors = {
       .map(key => state.uploadingImages.images[key])
       .filter(image => image.state === 'error' && image.remainingUploadAttempts > 0) as UploadingImage[]
   },
+  pendingImages: (state) => {
+    let keys: string[] = []
+    for (let key in state.uploadingImages.images) {
+      if (state.uploadingImages.images.hasOwnProperty(key) && state.uploadingImages.images[key].state === 'pending') {
+        keys.push(key)
+      }
+    }
+    return keys
+  },
   uploadingImageIds: (state) => {
     let keys: string[] = []
     for (let key in state.uploadingImages.images) {

--- a/App/Sagas/TextileSagas.ts
+++ b/App/Sagas/TextileSagas.ts
@@ -468,12 +468,14 @@ export function * photosTask () {
 
 export function * removePayloadFile (action: ActionType<typeof UploadingImagesActions.imageUploadComplete>) {
   // TODO: Seeing an error here where the file is sometimes not found on disk...
-  const { dataId } = action.payload
-  const uploadingImage: UploadingImage = yield select(UploadingImagesSelectors.uploadingImageById, dataId)
   try {
     // Putting this into a try, because although it might be nice to have the
     // error bubble up, we want to be sure we mark the image as uploaded
+    const { dataId } = action.payload
+    const uploadingImage: UploadingImage = yield select(UploadingImagesSelectors.uploadingImageById, dataId)
     yield call(RNFS.unlink, uploadingImage.path)
+  } catch (error) {
+    // nothing to do here
   } finally {
     yield put(UploadingImagesActions.imageRemovalComplete(dataId))
   }


### PR DESCRIPTION
here it is @asutula 

working really nicely. the spinner that i had since last night finally went through the queue and gave that NSInvalidArgumentException error. 

All the rest of the spinners I've creates since testing are going through fine now. 