### PR TITLE
small fix on feed to show when empty

### DIFF
--- a/App/SB/views/FeedList/index.js
+++ b/App/SB/views/FeedList/index.js
@@ -106,7 +106,7 @@ class Notifications extends React.PureComponent {
         {/*<FeedItemUpdate />*/}
         {this.props.showTourScreen && this._renderTour()}
         <View style={styles.contentContainer}>
-          {this.props.notifications.length === 0 &&
+          {this.props.profile && this.props.notifications.length === 0 &&
           <View style={feedItemStyle.itemContainer} >
             <View style={feedItemStyle.headerIconUser}>
               <View style={feedItemStyle.iconContainer}>


### PR DESCRIPTION
forgot again that the init state of arrays is len=0. avoids showing the placeholder after the user has used the app