### PR TITLE
Node lifecycle, background triggers

### DIFF
--- a/App/Redux/TextileNodeRedux.ts
+++ b/App/Redux/TextileNodeRedux.ts
@@ -10,27 +10,19 @@ const actions = {
   appStateChange: createAction('APP_STATE_CHANGE', resolve => {
     return (previousState: TextileAppStateStatus, newState: AppStateStatus) => resolve({ previousState, newState })
   }),
-  createNodeRequest: createAction('CREATE_NODE_REQUEST', resolve => {
-    return (path: string) => resolve({ path })
-  }),
-  createNodeSuccess: createAction('CREATE_NODE_SUCCESS', resolve => {
-    return () => resolve()
-  }),
+  creatingNode: createAction('CREATING_NODE'),
+  createNodeSuccess: createAction('CREATE_NODE_SUCCESS'),
   createNodeFailure: createAction('CREATE_NODE_FAILURE', resolve => {
     return (error: Error) => resolve({ error })
   }),
-  startNodeRequest: createAction('START_NODE_REQUEST', resolve => {
-    return () => resolve()
-  }),
+  startingNode: createAction('STARTING_NODE'),
   startNodeSuccess: createAction('START_NODE_SUCCESS', resolve => {
     return () => resolve()
   }),
   startNodeFailure: createAction('START_NODE_FAILURE', resolve => {
     return (error: Error) => resolve({ error })
   }),
-  stopNodeRequest: createAction('STOP_NODE_REQUEST', resolve => {
-    return () => resolve()
-  }),
+  stoppingNode: createAction('STOP_NODE_REQUEST'),
   stopNodeSuccess: createAction('STOP_NODE_SUCCESS', resolve => {
     return () => resolve()
   }),
@@ -110,15 +102,15 @@ export function reducer (state: TextileNodeState = initialState, action: Textile
       return { ...state, locked: action.payload.value }
     case getType(actions.appStateChange):
       return { ...state, appState: action.payload.newState }
-    case getType(actions.createNodeRequest):
+    case getType(actions.creatingNode):
       return { ...state, nodeState: { ...state.nodeState, state: 'creating' } }
     case getType(actions.createNodeSuccess):
       return { ...state, nodeState: { ...state.nodeState, state: 'stopped' } }
-    case getType(actions.startNodeRequest):
+    case getType(actions.startingNode):
       return { ...state, nodeState: { ...state.nodeState, state: 'starting' } }
     case getType(actions.startNodeSuccess):
       return { ...state, nodeState: {...state.nodeState, state: 'started' } }
-    case getType(actions.stopNodeRequest):
+    case getType(actions.stoppingNode):
       return { ...state, nodeState: { ...state.nodeState, state: 'stopping' } }
     case getType(actions.stopNodeSuccess):
       return { ...state, nodeState: { ...state.nodeState, state: 'stopped' } }

--- a/App/Redux/TextileNodeRedux.ts
+++ b/App/Redux/TextileNodeRedux.ts
@@ -12,22 +12,16 @@ const actions = {
   }),
   creatingNode: createAction('CREATING_NODE'),
   createNodeSuccess: createAction('CREATE_NODE_SUCCESS'),
-  createNodeFailure: createAction('CREATE_NODE_FAILURE', resolve => {
-    return (error: Error) => resolve({ error })
-  }),
   startingNode: createAction('STARTING_NODE'),
   startNodeSuccess: createAction('START_NODE_SUCCESS', resolve => {
     return () => resolve()
-  }),
-  startNodeFailure: createAction('START_NODE_FAILURE', resolve => {
-    return (error: Error) => resolve({ error })
   }),
   stoppingNode: createAction('STOP_NODE_REQUEST'),
   stopNodeSuccess: createAction('STOP_NODE_SUCCESS', resolve => {
     return () => resolve()
   }),
-  stopNodeFailure: createAction('STOP_NODE_FAILURE', resolve => {
-    return (error: Error) => resolve({ error })
+  nodeError: createAction('NODE_ERROR', resolve => {
+    return (error: any) => resolve({ error })
   }),
   nodeOnline: createAction('NODE_ONLINE', resolve => {
     return () => resolve()
@@ -75,13 +69,23 @@ type ThreadMap = {
 
 type TextileAppStateStatus = AppStateStatus | 'unknown'
 
+export enum NodeState {
+  'nonexistent' = 'nonexistent',
+  'creating' = 'creating',
+  'created' = 'created', // Node has been created, on it's way to being starting
+  'starting' = 'starting',
+  'started' = 'started',
+  'stopping' = 'stopping',
+  'stopped' = 'stopped' // Node has been explicitly stopped, different than created
+}
+
 type TextileNodeState = {
   readonly locked: boolean
   readonly appState: TextileAppStateStatus
   readonly online: boolean
   readonly nodeState: {
-    readonly state?: 'creating' | 'stopped' | 'starting' | 'started' | 'stopping'
-    readonly error?: Error
+    readonly state: NodeState
+    readonly error?: string
   }
   readonly threads: ThreadMap,
   readonly refreshingMessages: boolean
@@ -91,7 +95,9 @@ export const initialState: TextileNodeState = {
   locked: false,
   appState: 'unknown',
   online: false,
-  nodeState: {},
+  nodeState: {
+    state: NodeState.nonexistent
+  },
   threads: {},
   refreshingMessages: false
 }
@@ -103,21 +109,21 @@ export function reducer (state: TextileNodeState = initialState, action: Textile
     case getType(actions.appStateChange):
       return { ...state, appState: action.payload.newState }
     case getType(actions.creatingNode):
-      return { ...state, nodeState: { ...state.nodeState, state: 'creating' } }
+      return { ...state, nodeState: { ...state.nodeState, state: NodeState.creating } }
     case getType(actions.createNodeSuccess):
-      return { ...state, nodeState: { ...state.nodeState, state: 'stopped' } }
+      return { ...state, nodeState: { ...state.nodeState, state: NodeState.created } }
     case getType(actions.startingNode):
-      return { ...state, nodeState: { ...state.nodeState, state: 'starting' } }
+      return { ...state, nodeState: { ...state.nodeState, state: NodeState.starting } }
     case getType(actions.startNodeSuccess):
-      return { ...state, nodeState: {...state.nodeState, state: 'started' } }
+      return { ...state, nodeState: {...state.nodeState, state: NodeState.started } }
     case getType(actions.stoppingNode):
-      return { ...state, nodeState: { ...state.nodeState, state: 'stopping' } }
+      return { ...state, nodeState: { ...state.nodeState, state: NodeState.stopping } }
     case getType(actions.stopNodeSuccess):
-      return { ...state, nodeState: { ...state.nodeState, state: 'stopped' } }
-    case getType(actions.createNodeFailure):
-    case getType(actions.startNodeFailure):
-    case getType(actions.stopNodeFailure):
-      return { ...state, nodeState: { ...state.nodeState, error: action.payload.error } }
+      return { ...state, nodeState: { ...state.nodeState, state: NodeState.stopped } }
+    case getType(actions.nodeError):
+      const { error } = action.payload
+      const errorMessage = (error.message as string) || (error as string) || 'unknown'
+      return { ...state, nodeState: { ...state.nodeState, error: errorMessage } }
     case getType(actions.nodeOnline):
       return { ...state, online: true }
     case getType(actions.getPhotoHashesRequest): {
@@ -160,6 +166,7 @@ function createEmptyThreadData (): ThreadData {
 export const TextileNodeSelectors = {
   locked: (state: RootState) => state.textileNode.locked,
   appState: (state: RootState) => state.textileNode.appState,
+  nodeState: (state: RootState) => state.textileNode.nodeState.state,
   online: (state: RootState) => state.textileNode.online,
   threads: (state: RootState) => state.textileNode.threads,
   photosByThreadId: (state: any, threadId: string) => {

--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -1,27 +1,54 @@
-import { Action } from 'redux'
 import { delay } from 'redux-saga'
-import { take, call, put, fork, cancelled, race } from 'redux-saga/effects'
+import { take, call, put, fork, cancelled, race, select } from 'redux-saga/effects'
 import { ActionType, getType } from 'typesafe-actions'
 import RNFS from 'react-native-fs'
 import Config from 'react-native-config'
+import BackgroundTimer from 'react-native-background-timer'
 
-import TextileNodeActions from '../Redux/TextileNodeRedux'
+import TextileNodeActions, { TextileNodeSelectors, NodeState } from '../Redux/TextileNodeRedux'
 import TextileNode from '../../TextileNode'
 import { RootAction } from '../Redux/Types'
 
 export function * manageNode () {
-  yield fork(createAndStartNode)
   while (true) {
-    const action: ActionType<typeof TextileNodeActions.appStateChange> = yield take(getType(TextileNodeActions.appStateChange))
-    if (action.payload.newState === 'background') {
-      // This race cancels whichever effect looses the race, so a foreground event will cancel stopping the node
-      yield race({
-        delayAndStopNode: call(stopNodeAfterDelay, 20000),
-        foregroundEvent: take(
-          (action: RootAction) =>
-            action.type === getType(TextileNodeActions.appStateChange) && action.payload.newState === 'active'
+    try {
+      // Block until we get an active or background app state
+      const action: ActionType<typeof TextileNodeActions.appStateChange> =
+        yield take((action: RootAction) =>
+          action.type === getType(TextileNodeActions.appStateChange) && (action.payload.newState === 'active' || action.payload.newState === 'background')
         )
-      })
+      console.log('GOT APP STATE:', action.payload.newState)
+
+      // Get our current node state and create/start the node if it doesn't exist or is stopped
+      // Use fork so we don't block listening for the next app state change while the node is created and started
+      const nodeState: NodeState = yield select(TextileNodeSelectors.nodeState)
+      console.log('CURRENT NODE STATE:', nodeState)
+      if (nodeState === NodeState.nonexistent || nodeState === NodeState.stopped) {
+        console.log('CREATING/STARTING NODE')
+        yield fork(createAndStartNode)
+      }
+
+      // If we got a background app state, start a background task and schedule the node to be stopped in 20 seconds
+      //
+      // This background state can come from a active > background transition
+      // or by launching into the background because of a trigger.
+      //
+      // Using the race effect, if we get a foreground event while we're waiting
+      // to stop the node, cancel the stop and let it keep running
+      if (action.payload.newState === 'background') {
+        BackgroundTimer.start()
+        // This race cancels whichever effect looses the race, so a foreground event will cancel stopping the node
+        yield race({
+          delayAndStopNode: call(stopNodeAfterDelay, 20000),
+          foregroundEvent: take(
+            (action: RootAction) =>
+              action.type === getType(TextileNodeActions.appStateChange) && action.payload.newState === 'active'
+          )
+        })
+        BackgroundTimer.stop()
+      }
+    } catch (error) {
+      yield put(TextileNodeActions.nodeError(error))
     }
   }
 }
@@ -38,13 +65,19 @@ function * createAndStartNode () {
 }
 
 function * stopNodeAfterDelay (ms: number) {
+  console.log('RUNNING FOR MS:', ms)
   try {
-    yield call(delay, ms)
+    yield delay(ms)
+    console.log('DELAY OVER')
   } finally {
     if (yield cancelled()) {
       // Let it keep running
+      console.log('SHUT DOWN CANCELLED, STILL RUNNING')
     } else {
+      console.log('STOPPING NODE')
+      yield put(TextileNodeActions.stoppingNode())
       yield call(TextileNode.stop)
+      yield put(TextileNodeActions.stopNodeSuccess())
     }
   }
 }

--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -1,0 +1,50 @@
+import { Action } from 'redux'
+import { delay } from 'redux-saga'
+import { take, call, put, fork, cancelled, race } from 'redux-saga/effects'
+import { ActionType, getType } from 'typesafe-actions'
+import RNFS from 'react-native-fs'
+import Config from 'react-native-config'
+
+import TextileNodeActions from '../Redux/TextileNodeRedux'
+import TextileNode from '../../TextileNode'
+import { RootAction } from '../Redux/Types'
+
+export function * manageNode () {
+  yield fork(createAndStartNode)
+  while (true) {
+    const action: ActionType<typeof TextileNodeActions.appStateChange> = yield take(getType(TextileNodeActions.appStateChange))
+    if (action.payload.newState === 'background') {
+      // This race cancels whichever effect looses the race, so a foreground event will cancel stopping the node
+      yield race({
+        delayAndStopNode: call(stopNodeAfterDelay, 20000),
+        foregroundEvent: take(
+          (action: RootAction) =>
+            action.type === getType(TextileNodeActions.appStateChange) && action.payload.newState === 'active'
+        )
+      })
+    }
+  }
+}
+
+function * createAndStartNode () {
+  const logLevel = (__DEV__ ? 'DEBUG' : 'INFO')
+  const logFiles = !__DEV__
+  yield put(TextileNodeActions.creatingNode())
+  yield call(TextileNode.create, RNFS.DocumentDirectoryPath, Config.TEXTILE_CAFE_URI, logLevel, logFiles)
+  yield put(TextileNodeActions.createNodeSuccess())
+  yield put(TextileNodeActions.startingNode())
+  yield call(TextileNode.start)
+  yield put(TextileNodeActions.startNodeSuccess())
+}
+
+function * stopNodeAfterDelay (ms: number) {
+  try {
+    yield call(delay, ms)
+  } finally {
+    if (yield cancelled()) {
+      // Let it keep running
+    } else {
+      yield call(TextileNode.stop)
+    }
+  }
+}

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -59,12 +59,7 @@ import {
   viewThread,
   addFriends,
   initializeAppState,
-  handleNewAppState,
   toggleBackgroundTimer,
-  triggerCreateNode,
-  createNode,
-  startNode,
-  stopNode,
   refreshMessages,
   addDevice,
   getPhotoHashes,
@@ -97,10 +92,6 @@ export default function * root () {
     takeLatest(getType(AuthActions.requestCameraPermissions), cameraPermissionsTrigger),
     takeLatest(getType(PreferencesActions.toggleServicesRequest), updateServices),
 
-    // some sagas receive extra parameters in addition to an action
-
-    takeEvery(getType(TextileNodeActions.appStateChange), handleNewAppState),
-
     takeEvery(getType(UIActions.viewPhotoRequest), viewPhoto),
     takeEvery(getType(UIActions.viewThreadRequest), viewThread),
     takeEvery(getType(UIActions.addFriendRequest), addFriends),
@@ -118,13 +109,6 @@ export default function * root () {
     takeEvery(getType(TextileNodeActions.refreshMessagesRequest), refreshMessages),
 
     takeEvery(getType(TextileNodeActions.lock), toggleBackgroundTimer),
-
-    takeEvery(getType(TextileNodeActions.createNodeRequest), createNode),
-    takeEvery(getType(TextileNodeActions.startNodeRequest), startNode),
-    takeEvery(getType(TextileNodeActions.stopNodeRequest), stopNode),
-
-    // Actions that trigger creating (therefore starting/stopping) the node
-    takeEvery(getType(PreferencesActions.onboardedSuccess), triggerCreateNode),
 
     // If the user clicked any invites before creating an account, this will now flush them...
     takeEvery(getType(TextileNodeActions.startNodeSuccess), pendingInvitesTask),

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -16,6 +16,9 @@ import DevicesActions from '../Redux/DevicesRedux'
 /* ------------- Sagas ------------- */
 
 import { startup } from './StartupSagas'
+
+import { manageNode } from './NodeLifecycle'
+
 import {
   handleSharePhotoRequest,
   handleImageUploadComplete,
@@ -80,6 +83,8 @@ import {
 
 export default function * root () {
   yield all([
+    manageNode(),
+
     // some sagas only receive an action
     takeLatest(getType(StartupActions.startup), startup),
 


### PR DESCRIPTION
Feeling good about the node start/stop logic. Seems solid and will always run the node in the background for 20 seconds, whether the background session results from a foreground > background transition or from launching into the background because of a location or background fetch trigger.

Need some help:

I want to clean up all the things we do after the node is started and/or comes online. I deleted a bunch of old code, code that did some of those important things. Go through it with me and let's identify all the things that need to happen and exactly when/how they should happen.