### PR TITLE
Node lifecycle, background triggers (2)

### DIFF
--- a/App/Containers/App.tsx
+++ b/App/Containers/App.tsx
@@ -5,6 +5,7 @@ import {Provider} from 'react-redux'
 import {PersistGate} from 'redux-persist/integration/react'
 import RootContainer from './RootContainer'
 import configureStore from '../Redux/configureStore'
+import LocationEventHandler from '../Services/EventHandlers/LocationEventHandler'
 import AppStateEventHander from '../Services/EventHandlers/AppStateEventHandler'
 import TextileNodeEventHandler from '../Services/EventHandlers/TextileNodeEventHandler'
 import UploadEventHandler from '../Services/EventHandlers/UploadEventHandler'
@@ -18,6 +19,7 @@ const backgroundTaskEventHandler = new BackgroundTaskEventHandler(store)
 
 class App extends Component {
 
+  locationEventHandler = new LocationEventHandler(store)
   appStateEventHander = new AppStateEventHander(store)
   notificationEventHandler = new NotificationEventHandler(store)
   textileNodeEventHandler = new TextileNodeEventHandler(store)
@@ -42,6 +44,7 @@ class App extends Component {
     if (super.componentWillUnmount) {
       super.componentWillUnmount()
     }
+    this.locationEventHandler.tearDown()
     this.appStateEventHander.tearDown()
     this.notificationEventHandler.tearDown()
     this.textileNodeEventHandler.tearDown()

--- a/App/Containers/ThreadsList.js
+++ b/App/Containers/ThreadsList.js
@@ -213,7 +213,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => {
   return {
     viewThread: (threadId, threadName) => { dispatch(UIActions.viewThreadRequest(threadId, threadName)) },
-    refreshMessages: (hidden) => { dispatch(TextileNodeActions.refreshMessagesRequest(hidden)) },
+    refreshMessages: () => { dispatch(TextileNodeActions.refreshMessagesRequest()) },
     completeScreen: (name) => { dispatch(PreferencesActions.completeTourSuccess(name)) },
     enableNotifications: () => { dispatch(PreferencesActions.toggleServicesRequest('notifications', true)) }
   }

--- a/App/Redux/TextileNodeRedux.ts
+++ b/App/Redux/TextileNodeRedux.ts
@@ -4,9 +4,6 @@ import * as TextileTypes from '../Models/TextileTypes'
 import {RootState} from './Types'
 
 const actions = {
-  lock: createAction('LOCK', resolve => {
-    return (value: boolean) => resolve({ value })
-  }),
   appStateChange: createAction('APP_STATE_CHANGE', resolve => {
     return (previousState: TextileAppStateStatus, newState: AppStateStatus) => resolve({ previousState, newState })
   }),
@@ -72,7 +69,7 @@ type TextileAppStateStatus = AppStateStatus | 'unknown'
 export enum NodeState {
   'nonexistent' = 'nonexistent',
   'creating' = 'creating',
-  'created' = 'created', // Node has been created, on it's way to being starting
+  'created' = 'created', // Node has been created, on it's way to starting
   'starting' = 'starting',
   'started' = 'started',
   'stopping' = 'stopping',
@@ -80,7 +77,6 @@ export enum NodeState {
 }
 
 type TextileNodeState = {
-  readonly locked: boolean
   readonly appState: TextileAppStateStatus
   readonly online: boolean
   readonly nodeState: {
@@ -92,7 +88,6 @@ type TextileNodeState = {
 }
 
 export const initialState: TextileNodeState = {
-  locked: false,
   appState: 'unknown',
   online: false,
   nodeState: {
@@ -104,8 +99,6 @@ export const initialState: TextileNodeState = {
 
 export function reducer (state: TextileNodeState = initialState, action: TextileNodeAction): TextileNodeState {
   switch (action.type) {
-    case getType(actions.lock):
-      return { ...state, locked: action.payload.value }
     case getType(actions.appStateChange):
       return { ...state, appState: action.payload.newState }
     case getType(actions.creatingNode):

--- a/App/Redux/TextileNodeRedux.ts
+++ b/App/Redux/TextileNodeRedux.ts
@@ -41,9 +41,6 @@ const actions = {
   refreshMessagesRequest: createAction('REFRESH_MESSAGES_REQUEST', resolve => {
     return () => resolve()
   }),
-  refreshMessagesSubmitted: createAction('REFRESH_MESSAGES_SUBMITTED', resolve => {
-    return () => resolve()
-  }),
   refreshMessagesSuccess: createAction('REFRESH_MESSAGES_SUCCESS', resolve => {
     return (timestamp: number) => resolve({ timestamp })
   }),
@@ -138,7 +135,7 @@ export function reducer (state: TextileNodeState = initialState, action: Textile
       const threads = { ...state.threads, [threadId]: { ...threadData, querying: false, error } }
       return { ...state, threads }
     }
-    case getType(actions.refreshMessagesSubmitted):
+    case getType(actions.refreshMessagesRequest):
       return { ...state, refreshingMessages: true }
     case getType(actions.refreshMessagesSuccess):
     case getType(actions.refreshMessagesFailure):

--- a/App/Redux/ThreadsRedux.ts
+++ b/App/Redux/ThreadsRedux.ts
@@ -148,7 +148,7 @@ export function reducer (state: ThreadsState = initialState, action: ThreadsActi
     case getType(actions.refreshThreadsRequest):
       return { ...state, refreshing: true, refreshError: undefined }
     case getType(actions.refreshThreadsSuccess):
-      const threads = action.payload.threads.items || []
+      const threads = action.payload.threads.items
       return { ...state, refreshing: false, refreshError: undefined, threads }
     case getType(actions.refreshThreadsError):
       return { ...state, refreshing: false, refreshError: action.payload.error }

--- a/App/SB/views/Settings/GetServiceInfo.js
+++ b/App/SB/views/Settings/GetServiceInfo.js
@@ -1,11 +1,11 @@
 export default function (service: string): {[index: string]: string} | undefined {
   switch (service) {
-    // case 'backgroundLocation':
-    //   return {
-    //     title: 'Always allow location',
-    //     subtitle: 'Better background updates',
-    //     details: 'Background location allows Textile to wake up periodically to check for updates to your camera roll and to check for updates on your peer-to-peer network. Without background location the app will never get any new information, it will be a pretty boring place. We never keep, store, process, or share your location data with anyone or any device.'
-    //   }
+    case 'backgroundLocation':
+      return {
+        title: 'Always allow location',
+        subtitle: 'Better background updates',
+        details: 'Background location allows Textile to wake up periodically to check for updates on your peer-to-peer network. Without background location the app will never get any new information, it will be a pretty boring place. We never keep, store, process, or share your location data with anyone or any device.'
+      }
     case 'notifications':
       return {
         title: 'Notifications',

--- a/App/SB/views/Settings/index.js
+++ b/App/SB/views/Settings/index.js
@@ -29,7 +29,7 @@ class AccountSettings extends React.PureComponent {
   static navigationOptions = ({ navigation }) => {
     const params = navigation.state.params || {}
     return {
-      headerTitle: 'Notifications',
+      headerTitle: 'Settings',
       headerLeft: (
         <TextileHeaderButtons left>
           <TextileItem title='Back' iconName='arrow-left' onPress={() => { navigation.dispatch(NavigationActions.back()) }} />

--- a/App/SB/views/ThreadsDetail/index.js
+++ b/App/SB/views/ThreadsDetail/index.js
@@ -69,7 +69,7 @@ class ThreadsDetail extends React.PureComponent {
 
   componentWillMount () {
     // refresh our messages
-    this.props.refreshMessages(true)
+    this.props.refreshMessages()
   }
 
   componentDidMount () {
@@ -272,7 +272,7 @@ const mapDispatchToProps = (dispatch) => {
     dismissPhoto: () => { dispatch(UIActions.dismissViewedPhoto()) },
     viewPhoto: (photoId, threadId) => { dispatch(UIActions.viewPhotoRequest(photoId, threadId)) },
     showImagePicker: (threadId) => { dispatch(UIActions.showImagePicker(threadId)) },
-    refreshMessages: (hidden) => { dispatch(TextileNodeActions.refreshMessagesRequest(hidden)) },
+    refreshMessages: () => { dispatch(TextileNodeActions.refreshMessagesRequest()) },
     toggleVerboseUi: () => { dispatch(PreferencesActions.toggleVerboseUi()) },
     leaveThread: (threadId: string) => { dispatch(ThreadsActions.removeThreadRequest(threadId)) },
     dismissError: () => { dispatch(UIActions.dismissImagePickerError()) },

--- a/App/SB/views/UserProfile/index.js
+++ b/App/SB/views/UserProfile/index.js
@@ -108,7 +108,7 @@ class UserProfile extends React.PureComponent {
           </View>
           {this.connectivity()}
           <TouchableOpacity style={styles.listItemFirst} onPress={this._settings.bind(this)}>
-            <Text style={styles.listText}>Notifications</Text>
+            <Text style={styles.listText}>Settings</Text>
           </TouchableOpacity>
           <TouchableOpacity style={styles.listItem} onPress={this._changeAvatar.bind(this)}>
             <Text style={styles.listText}>Change Avatar</Text>

--- a/App/Sagas/NodeCreated.ts
+++ b/App/Sagas/NodeCreated.ts
@@ -1,0 +1,17 @@
+import { call, put, take } from 'redux-saga/effects'
+import { getType } from 'typesafe-actions'
+import TextileNode from '../../TextileNode'
+import PreferencesActions from '../Redux/PreferencesRedux'
+import TextileNodeActions from '../Redux/TextileNodeRedux'
+
+
+export function * onNodeCreated () {
+  while (yield take(getType(TextileNodeActions.createNodeSuccess))) {
+    try {
+      const mnemonic: string = yield call(TextileNode.mnemonic)
+      yield put(PreferencesActions.updatecMnemonic(mnemonic))
+    } catch {
+      // This only succeeds when the node is first created so this error is expected
+    }
+  }
+}

--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -1,0 +1,83 @@
+import { delay } from 'redux-saga'
+import { take, call, put, fork, cancelled, race, select } from 'redux-saga/effects'
+import { ActionType, getType } from 'typesafe-actions'
+import RNFS from 'react-native-fs'
+import Config from 'react-native-config'
+import BackgroundTimer from 'react-native-background-timer'
+
+import TextileNodeActions, { TextileNodeSelectors, NodeState } from '../Redux/TextileNodeRedux'
+import TextileNode from '../../TextileNode'
+import { RootAction } from '../Redux/Types'
+
+export function * manageNode () {
+  while (true) {
+    try {
+      // Block until we get an active or background app state
+      const action: ActionType<typeof TextileNodeActions.appStateChange> =
+        yield take((action: RootAction) =>
+          action.type === getType(TextileNodeActions.appStateChange) && (action.payload.newState === 'active' || action.payload.newState === 'background')
+        )
+      console.log('GOT APP STATE:', action.payload.newState)
+
+      // Get our current node state and create/start the node if it doesn't exist or is stopped
+      // Use fork so we don't block listening for the next app state change while the node is created and started
+      const nodeState: NodeState = yield select(TextileNodeSelectors.nodeState)
+      console.log('CURRENT NODE STATE:', nodeState)
+      if (nodeState === NodeState.nonexistent || nodeState === NodeState.stopped) {
+        console.log('CREATING/STARTING NODE')
+        yield fork(createAndStartNode)
+      }
+
+      // If we got a background app state, start a background task and schedule the node to be stopped in 20 seconds
+      //
+      // This background state can come from a active > background transition
+      // or by launching into the background because of a trigger.
+      //
+      // Using the race effect, if we get a foreground event while we're waiting
+      // to stop the node, cancel the stop and let it keep running
+      if (action.payload.newState === 'background') {
+        BackgroundTimer.start()
+        // This race cancels whichever effect looses the race, so a foreground event will cancel stopping the node
+        yield race({
+          delayAndStopNode: call(stopNodeAfterDelay, 20000),
+          foregroundEvent: take(
+            (action: RootAction) =>
+              action.type === getType(TextileNodeActions.appStateChange) && action.payload.newState === 'active'
+          )
+        })
+        BackgroundTimer.stop()
+      }
+    } catch (error) {
+      yield put(TextileNodeActions.nodeError(error))
+    }
+  }
+}
+
+function * createAndStartNode () {
+  const logLevel = (__DEV__ ? 'DEBUG' : 'INFO')
+  const logFiles = !__DEV__
+  yield put(TextileNodeActions.creatingNode())
+  yield call(TextileNode.create, RNFS.DocumentDirectoryPath, Config.TEXTILE_CAFE_URI, logLevel, logFiles)
+  yield put(TextileNodeActions.createNodeSuccess())
+  yield put(TextileNodeActions.startingNode())
+  yield call(TextileNode.start)
+  yield put(TextileNodeActions.startNodeSuccess())
+}
+
+function * stopNodeAfterDelay (ms: number) {
+  console.log('RUNNING FOR MS:', ms)
+  try {
+    yield delay(ms)
+    console.log('DELAY OVER')
+  } finally {
+    if (yield cancelled()) {
+      // Let it keep running
+      console.log('SHUT DOWN CANCELLED, STILL RUNNING')
+    } else {
+      console.log('STOPPING NODE')
+      yield put(TextileNodeActions.stoppingNode())
+      yield call(TextileNode.stop)
+      yield put(TextileNodeActions.stopNodeSuccess())
+    }
+  }
+}

--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -17,14 +17,11 @@ export function * manageNode () {
         yield take((action: RootAction) =>
           action.type === getType(TextileNodeActions.appStateChange) && (action.payload.newState === 'active' || action.payload.newState === 'background')
         )
-      console.log('GOT APP STATE:', action.payload.newState)
 
       // Get our current node state and create/start the node if it doesn't exist or is stopped
       // Use fork so we don't block listening for the next app state change while the node is created and started
       const nodeState: NodeState = yield select(TextileNodeSelectors.nodeState)
-      console.log('CURRENT NODE STATE:', nodeState)
       if (nodeState === NodeState.nonexistent || nodeState === NodeState.stopped) {
-        console.log('CREATING/STARTING NODE')
         yield fork(createAndStartNode)
       }
 
@@ -65,16 +62,12 @@ function * createAndStartNode () {
 }
 
 function * stopNodeAfterDelay (ms: number) {
-  console.log('RUNNING FOR MS:', ms)
   try {
     yield delay(ms)
-    console.log('DELAY OVER')
   } finally {
     if (yield cancelled()) {
       // Let it keep running
-      console.log('SHUT DOWN CANCELLED, STILL RUNNING')
     } else {
-      console.log('STOPPING NODE')
       yield put(TextileNodeActions.stoppingNode())
       yield call(TextileNode.stop)
       yield put(TextileNodeActions.stopNodeSuccess())

--- a/App/Sagas/NodeOnline.ts
+++ b/App/Sagas/NodeOnline.ts
@@ -1,0 +1,9 @@
+import { put, take } from 'redux-saga/effects'
+import { getType } from 'typesafe-actions'
+import TextileNodeActions from '../Redux/TextileNodeRedux'
+
+export function * onNodeOnline () {
+  while (yield take(getType(TextileNodeActions.nodeOnline))) {
+    yield put(TextileNodeActions.refreshMessagesRequest())
+  }
+}

--- a/App/Sagas/NodeStarted.ts
+++ b/App/Sagas/NodeStarted.ts
@@ -1,0 +1,27 @@
+import { all, call, put, take } from 'redux-saga/effects'
+import { getType } from 'typesafe-actions'
+import TextileNode from '../../TextileNode'
+import AuthActions from '../Redux/AuthRedux'
+import PreferencesActions from '../Redux/PreferencesRedux'
+import TextileNodeActions from '../Redux/TextileNodeRedux'
+import ThreadsActions from '../Redux/ThreadsRedux'
+
+export function * onNodeStarted () {
+  while (yield take(getType(TextileNodeActions.startNodeSuccess))) {
+    yield all([
+      put(ThreadsActions.refreshThreadsRequest()),
+      call(refreshTokens),
+      call(refreshPublicKey)
+    ])
+  }
+}
+
+function * refreshTokens () {
+  const tokens = yield call(TextileNode.getTokens)
+  yield put(AuthActions.getTokensSuccess(tokens))
+}
+
+function * refreshPublicKey () {
+  const publicKey = yield call(TextileNode.getPublicKey)
+  yield put(PreferencesActions.getPublicKeySuccess(publicKey))
+}

--- a/App/Sagas/TextileSagas.ts
+++ b/App/Sagas/TextileSagas.ts
@@ -185,15 +185,6 @@ export function * viewPhoto ( action: ActionType<typeof UIActions.viewPhotoReque
   yield call(NavigationService.navigate, 'PhotoViewer')
 }
 
-export function * toggleBackgroundTimer (action: ActionType<typeof TextileNodeActions.lock>) {
-  if (action.payload.value) {
-    yield call(BackgroundTimer.start)
-  } else {
-    yield call(BackgroundTimer.stop)
-    yield call(BackgroundTask.finish)
-  }
-}
-
 export function * initializeAppState () {
     yield take(getType(StartupActions.startup))
     const defaultAppState = yield select(TextileNodeSelectors.appState)
@@ -500,8 +491,8 @@ export function * cameraPermissionsTrigger () {
   // Will trigger a camera permission request
   if (Platform.OS === 'android') {
     const permission = yield call(PermissionsAndroid.request, PermissionsAndroid.PERMISSIONS.READ_EXTERNAL_STORAGE, {
-        'title': 'Textile Photos Photos Permission',
-        'message': 'Textile accesses your photo storage to import any new photos you take after you install the app.'
+        title: 'Textile Photos Photos Permission',
+        message: 'Textile accesses your photo storage to import any new photos you take after you install the app.'
       })
   } else {
     getPhotos(1)

--- a/App/Sagas/TextileSagas.ts
+++ b/App/Sagas/TextileSagas.ts
@@ -150,7 +150,7 @@ function * processAvatarImage(uri: string, defaultThread: TextileTypes.Thread) {
 }
 
 export function * viewThread ( action: ActionType<typeof UIActions.viewThreadRequest> ) {
-  yield call(TextileNodeActions.refreshMessagesRequest, false)
+  yield put(TextileNodeActions.refreshMessagesRequest())
   yield call(NavigationService.navigate, 'ViewThread', { id: action.payload.threadId, name: action.payload.threadName })
 }
 

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -16,6 +16,9 @@ import DevicesActions from '../Redux/DevicesRedux'
 /* ------------- Sagas ------------- */
 
 import { startup } from './StartupSagas'
+
+import { manageNode } from './NodeLifecycle'
+
 import {
   handleSharePhotoRequest,
   handleImageUploadComplete,
@@ -57,12 +60,7 @@ import {
   viewThread,
   addFriends,
   initializeAppState,
-  handleNewAppState,
   toggleBackgroundTimer,
-  triggerCreateNode,
-  createNode,
-  startNode,
-  stopNode,
   refreshMessages,
   addDevice,
   getPhotoHashes,
@@ -81,6 +79,8 @@ import {
 
 export default function * root () {
   yield all([
+    manageNode(),
+
     // some sagas only receive an action
     takeLatest(getType(StartupActions.startup), startup),
 
@@ -92,10 +92,6 @@ export default function * root () {
     // permissions request events
     takeLatest(getType(AuthActions.requestCameraPermissions), cameraPermissionsTrigger),
     takeLatest(getType(PreferencesActions.toggleServicesRequest), updateServices),
-
-    // some sagas receive extra parameters in addition to an action
-
-    takeEvery(getType(TextileNodeActions.appStateChange), handleNewAppState),
 
     takeEvery(getType(UIActions.viewPhotoRequest), viewPhoto),
     takeEvery(getType(UIActions.viewThreadRequest), viewThread),
@@ -114,13 +110,6 @@ export default function * root () {
     takeEvery(getType(TextileNodeActions.refreshMessagesRequest), refreshMessages),
 
     takeEvery(getType(TextileNodeActions.lock), toggleBackgroundTimer),
-
-    takeEvery(getType(TextileNodeActions.createNodeRequest), createNode),
-    takeEvery(getType(TextileNodeActions.startNodeRequest), startNode),
-    takeEvery(getType(TextileNodeActions.stopNodeRequest), stopNode),
-
-    // Actions that trigger creating (therefore starting/stopping) the node
-    takeEvery(getType(PreferencesActions.onboardedSuccess), triggerCreateNode),
 
     // If the user clicked any invites before creating an account, this will now flush them...
     takeEvery(getType(TextileNodeActions.startNodeSuccess), pendingInvitesTask),

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -112,7 +112,7 @@ export default function * root () {
     takeEvery(getType(TextileNodeActions.getPhotoHashesRequest), getPhotoHashes),
     takeEvery(getType(TextileNodeActions.ignorePhotoRequest), ignorePhoto),
 
-    takeEvery(getType(TextileNodeActions.refreshMessagesRequest), refreshMessages),
+    call(refreshMessages),
 
     // If the user clicked any invites before creating an account, this will now flush them...
     takeEvery(getType(TextileNodeActions.startNodeSuccess), pendingInvitesTask),

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -1,4 +1,4 @@
-import { takeLatest, takeEvery, all, take } from 'redux-saga/effects'
+import { takeLatest, takeEvery, all, call } from 'redux-saga/effects'
 import { getType } from 'typesafe-actions'
 
 /* ------------- Types ------------- */
@@ -18,6 +18,9 @@ import DevicesActions from '../Redux/DevicesRedux'
 import { startup } from './StartupSagas'
 
 import { manageNode } from './NodeLifecycle'
+import { onNodeCreated } from './NodeCreated'
+import { onNodeStarted } from './NodeStarted'
+import { onNodeOnline } from './NodeOnline'
 
 import {
   handleSharePhotoRequest,
@@ -78,7 +81,10 @@ import {
 
 export default function * root () {
   yield all([
-    manageNode(),
+    call(manageNode),
+    call(onNodeCreated),
+    call(onNodeStarted),
+    call(onNodeOnline),
 
     // some sagas only receive an action
     takeLatest(getType(StartupActions.startup), startup),

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -60,7 +60,6 @@ import {
   viewThread,
   addFriends,
   initializeAppState,
-  toggleBackgroundTimer,
   refreshMessages,
   addDevice,
   getPhotoHashes,
@@ -108,8 +107,6 @@ export default function * root () {
     takeEvery(getType(TextileNodeActions.ignorePhotoRequest), ignorePhoto),
 
     takeEvery(getType(TextileNodeActions.refreshMessagesRequest), refreshMessages),
-
-    takeEvery(getType(TextileNodeActions.lock), toggleBackgroundTimer),
 
     // If the user clicked any invites before creating an account, this will now flush them...
     takeEvery(getType(TextileNodeActions.startNodeSuccess), pendingInvitesTask),

--- a/App/Services/EventHandlers/LocationEventHandler.ts
+++ b/App/Services/EventHandlers/LocationEventHandler.ts
@@ -1,0 +1,42 @@
+import { Store } from 'redux'
+import { Platform, PermissionsAndroid } from 'react-native'
+
+import { RootState } from '../../Redux/Types'
+
+import TriggersActions from '../../Redux/TriggersRedux'
+
+export default class LocationEventHandler {
+  store: Store<RootState>
+
+  constructor(store: Store<RootState>) {
+    this.store = store
+    this.setup()
+  }
+
+  handleNewPosition () {
+    this.store.dispatch(TriggersActions.locationUpdate())
+  }
+
+  setup () {
+    if (Platform.OS === 'android') {
+      this.setupAndroid()
+    } else {
+      this.watchPosition()
+    }
+  }
+
+  async setupAndroid() {
+    const hasPermission = await PermissionsAndroid.checkPermission(PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION)
+    if (hasPermission) {
+      this.watchPosition()
+    }
+  }
+
+  watchPosition () {
+    navigator.geolocation.watchPosition(this.handleNewPosition.bind(this), undefined, { useSignificantChanges: true })
+  }
+
+  tearDown () {
+
+  }
+}


### PR DESCRIPTION
Feeling good about the node start/stop logic. Seems solid and will always run the node in the background for 20 seconds, whether the background session results from a foreground > background transition or from launching into the background because of a location or background fetch trigger.

Need some help:

I want to clean up all the things we do after the node is started and/or comes online. I deleted a bunch of old code, code that did some of those important things. Go through it with me and let's identify all the things that need to happen and exactly when/how they should happen.

Todo:
- [x] Fire off things that should happen once the node is created
- [x] Fire off things that should happen once the node is started
- [x] Create UI and logic for enabling background location