### PR TITLE
Move location monitor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,7 +120,6 @@ jobs:
 
             - run:
                 command: bundle exec fastlane beta
-                working_directory: ~/textile-mobile/android/fastlane
 
     ios:
         macos:

--- a/App/Containers/App.tsx
+++ b/App/Containers/App.tsx
@@ -19,7 +19,6 @@ const backgroundTaskEventHandler = new BackgroundTaskEventHandler(store)
 
 class App extends Component {
 
-  locationEventHandler = new LocationEventHandler(store)
   appStateEventHander = new AppStateEventHander(store)
   notificationEventHandler = new NotificationEventHandler(store)
   textileNodeEventHandler = new TextileNodeEventHandler(store)
@@ -44,7 +43,6 @@ class App extends Component {
     if (super.componentWillUnmount) {
       super.componentWillUnmount()
     }
-    this.locationEventHandler.tearDown()
     this.appStateEventHander.tearDown()
     this.notificationEventHandler.tearDown()
     this.textileNodeEventHandler.tearDown()

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -19,7 +19,7 @@ platform :android do
 
   def set_version_code(gradle_build: 'app/build.gradle', version: 0)
     sh 'pwd'
-    sh %Q{cd ../ && echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{version})}1' #{gradle_build})" > #{gradle_build} && cd -}
+    sh %Q{echo "$(awk '{sub(/versionCode [[:digit:]]+$/,"versionCode "#{version})}1' #{gradle_build})" > #{gradle_build}}
   end
 
   desc "Runs all the tests"


### PR DESCRIPTION
Issue is we need access to the persisted preferences state to decide whether or not to start monitoring. That state wasn't available in `App.tsx` (too early, state not rehydrated from persistence yet). So for now, I moved the logic to `RootContainer` which isn't rendered until persistence is done initializing. Not the long term solution... I think we can do this as a saga real nice, just need a little more time to figure it out not on a Friday night.