### PR TITLE
Make sure default thread is created before startNodeSuccess

### DIFF
--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -8,6 +8,7 @@ import BackgroundTimer from 'react-native-background-timer'
 import TextileNodeActions, { TextileNodeSelectors, NodeState } from '../Redux/TextileNodeRedux'
 import TextileNode from '../../TextileNode'
 import { RootAction } from '../Redux/Types'
+import { Threads, ThreadName } from '../Models/TextileTypes'
 
 export function * manageNode () {
   while (true) {
@@ -58,6 +59,11 @@ function * createAndStartNode () {
   yield put(TextileNodeActions.createNodeSuccess())
   yield put(TextileNodeActions.startingNode())
   yield call(TextileNode.start)
+  const threads: Threads = yield call(TextileNode.threads)
+  const defaultThread = threads.items.find(thread => thread.name === 'default')
+  if (!defaultThread) {
+    yield call(TextileNode.addThread, 'default' as ThreadName)
+  }
   yield put(TextileNodeActions.startNodeSuccess())
 }
 

--- a/App/Sagas/TextileSagas.ts
+++ b/App/Sagas/TextileSagas.ts
@@ -94,27 +94,12 @@ export function * updateNodeOverview ( action: ActionType<typeof TextileNodeActi
   }
 }
 
-export function * onboardedSuccess(action: ActionType<typeof PreferencesActions.onboardedSuccess>) {
-  let defaultThread: TT.Thread = yield call(getDefaultThread)
-  if (!defaultThread) {
-    // Skipping the normal addThread request here because we don't
-    // want to redirect to the default thread after complete
-    const thread: Thread = yield call(TextileNode.addThread, 'default' as TT.ThreadName)
-    yield put(ThreadsActions.addThreadSuccess(thread))
-    yield put(ThreadsActions.refreshThreadsRequest())
-  }
-}
-
 export function * handleProfilePhotoSelected(action: ActionType<typeof UIActions.selectProfilePicture>) {
   yield put(PreferencesActions.onboardedSuccess())
   yield call(NavigationService.navigate, 'PrimaryNavigation')
 
   // PreferencesActions.onboardedSuccess will setup the node/default thread, so wait for those
   let defaultThread: TT.Thread = yield call(getDefaultThread)
-  while (!defaultThread) {
-    yield call(delay, 150)
-    defaultThread = yield call(getDefaultThread)
-  }
   yield * processAvatarImage(action.payload.uri, defaultThread)
 }
 
@@ -311,13 +296,7 @@ export function * photosTask () {
     // will run before the next startNodeSuccess is received and photoTask run again
     yield take(getType(TextileNodeActions.startNodeSuccess))
 
-    let defaultThread: TT.Thread | undefined = yield call(getDefaultThread)
-    if (!defaultThread) {
-      yield put(ThreadsActions.addThreadRequest('default' as TT.ThreadName))
-      const action: ActionType<typeof ThreadsActions.addThreadSuccess> = yield take(getType(ThreadsActions.addThreadSuccess))
-      defaultThread = action.payload.thread
-      yield put(ThreadsActions.refreshThreadsRequest())
-    }
+    let defaultThread: TT.Thread = yield call(getDefaultThread)
 
     const queriredPhotosInitialized: boolean = yield select(cameraRollSelectors.initialized)
     if (!queriredPhotosInitialized) {

--- a/App/Sagas/ThreadsSagas.ts
+++ b/App/Sagas/ThreadsSagas.ts
@@ -50,9 +50,9 @@ export function * acceptExternalInvite (action: ActionType<typeof ThreadsActions
   }
 }
 
-export async function getDefaultThread (): Promise<Thread | undefined> {
+export async function getDefaultThread (): Promise<Thread> {
   const threads = await TextileNode.threads()
-  return threads.items.find(thread => thread.name === 'default')
+  return threads.items.find(thread => thread.name === 'default')!
 }
 
 export function * pendingInvitesTask () {

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -61,7 +61,6 @@ import {
   logOut,
   updateNodeOverview,
   recoverPassword,
-  onboardedSuccess,
   viewPhoto,
   viewThread,
   addFriends,
@@ -92,8 +91,6 @@ export default function * root () {
 
     // some sagas only receive an action
     takeLatest(getType(StartupActions.startup), startup),
-
-    takeEvery(getType(PreferencesActions.onboardedSuccess), onboardedSuccess),
 
     // profile photo
     takeEvery(getType(UIActions.chooseProfilePhotoRequest), chooseProfilePhoto),


### PR DESCRIPTION
Ok i think this is simple and works. Idea is to make sure the default thread exists right after stating the node, but before dispatching the `startNodeSuccess` action. Since we don't really run any code until after the node is started, it is then safe to assume the default thread exists everywhere else. Fixes #428 