### PR TITLE
Always display cancel share. Cancel upload if needed.

### DIFF
--- a/App/Components/ProcessingImage.tsx
+++ b/App/Components/ProcessingImage.tsx
@@ -70,11 +70,14 @@ const ProcessingImage = (props: ProcessingImageProps) => {
       </Fragment>
   } else {
     content =
-      <View style={STACK}>
-        <Text style={STATUS} />
-        <ProgressBar progress={progress} />
-        <Text style={STATUS}>{message}</Text>
-      </View>
+      <Fragment>
+        <View style={STACK}>
+          <Text style={STATUS} />
+          <ProgressBar progress={progress} />
+          <Text style={STATUS}>{message}</Text>
+        </View>
+        {cancel && <Button title='Cancel' onPress={cancel} />}
+      </Fragment>
   }
 
   return (

--- a/App/Sagas/ImageSharingTriggers.ts
+++ b/App/Sagas/ImageSharingTriggers.ts
@@ -1,6 +1,8 @@
 import { call, put, select } from 'redux-saga/effects'
 import { ActionType } from 'typesafe-actions'
 import RNFS from 'react-native-fs'
+import Upload from 'react-native-background-upload'
+
 import { PhotoId } from '../Models/TextileTypes'
 
 import ProcessingImagesActions, { ProcessingImage, ProcessingImagesSelectors } from '../Redux/ProcessingImagesRedux'
@@ -56,6 +58,10 @@ export function * cancelImageShare (action: ActionType<typeof ProcessingImagesAc
     const processingImage: ProcessingImage | undefined = yield select(ProcessingImagesSelectors.processingImageByUuid, uuid)
     if (!processingImage) {
       return
+    }
+
+    if (processingImage.state === 'uploading') {
+      yield call(Upload.cancelUpload, processingImage.uuid)
     }
 
     // Delete the shared image if needed


### PR DESCRIPTION
Allows cancel before it's too late and that embarrassing picture goes out. Also allows cancelling or errored out or hung shares. Band aid fix for #425 