### PR TITLE
bump go-mobile@0.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tslint": "tslint -c tslint.json --project ."
   },
   "dependencies": {
-    "@textile/go-mobile": "^0.1.8",
+    "@textile/go-mobile": "^0.1.9",
     "apisauce": "^0.14.2",
     "format-json": "^1.0.3",
     "identity-obj-proxy": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -608,9 +608,9 @@
     react-treebeard "^2.1.0"
     redux "^3.7.2"
 
-"@textile/go-mobile@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-0.1.8.tgz#4c39297c1cc6b86fce5172faf49ac22eccebceab"
+"@textile/go-mobile@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-0.1.9.tgz#7bcf39cb2f95dd200afb6ff45f1cdc6bde972cee"
 
 "@types/jest@^23.1.3":
   version "23.1.3"


### PR DESCRIPTION
Yet another framework update.

- Adds a panic catch (that may or may not work, need to see) for this crash: https://fabric.io/we-are-set-inc/ios/apps/io.textile.wallet/issues/5b982b6d6007d59fcd61a83a?time=last-thirty-days
- Does not set services like `TextileService` to `nil` on `Stop()`... have a hunch this may be the root cause of a few of these crashes from trying to access de-allocated objects (`EXC_BAD_ACCESS KERN_INVALID_ADDRESS`)

