### PR TITLE
Debug install beside production

### DIFF
--- a/App/Services/DeepLink.ts
+++ b/App/Services/DeepLink.ts
@@ -2,6 +2,7 @@ import NavigationService from './NavigationService'
 import Config from 'react-native-config'
 import { ExternalInvite, DeepLinkData } from '../Models/TextileTypes'
 
+
 function getParams (hash: string): { [key: string]: (string | string[]) } {
   const query = hash.replace('#', '')
   const vars = query.split('&').map((expression) => expression.split('='))
@@ -39,7 +40,7 @@ function getData (href: string): DeepLinkData | undefined {
     host: match[2],
     hostname: match[3],
     port: match[4],
-    path: match[5],
+    path: match[5].replace('/debug', ''),
     search: match[6],
     hash: match[7]
   }
@@ -53,6 +54,9 @@ function createInviteLink (invite: ExternalInvite, threadName: string): string {
   hash.push(`name=${encodeURIComponent(threadName)}`)
   if (Config.TEMPORARY_REFERRAL) {
     hash.push(`referral=${encodeURIComponent(Config.TEMPORARY_REFERRAL)}`)
+  }
+  if (__DEV__) {
+    return `https://www.textile.photos/debug/invites/new#${hash.join('&')}`
   }
   return `https://www.textile.photos/invites/new#${hash.join('&')}`
 }

--- a/App/Services/DeepLink.ts
+++ b/App/Services/DeepLink.ts
@@ -2,6 +2,8 @@ import NavigationService from './NavigationService'
 import Config from 'react-native-config'
 import { ExternalInvite, DeepLinkData } from '../Models/TextileTypes'
 
+const DEBUG_PATH_PREFIX = '/debug'
+
 function getParams (hash: string): { [key: string]: (string | string[]) } {
   const query = hash.replace('#', '')
   const vars = query.split('&').map((expression) => expression.split('='))
@@ -39,7 +41,7 @@ function getData (href: string): DeepLinkData | undefined {
     host: match[2],
     hostname: match[3],
     port: match[4],
-    path: match[5].replace('/debug', ''),
+    path: match[5].replace(DEBUG_PATH_PREFIX, ''),
     search: match[6],
     hash: match[7]
   }

--- a/App/Services/DeepLink.ts
+++ b/App/Services/DeepLink.ts
@@ -2,7 +2,6 @@ import NavigationService from './NavigationService'
 import Config from 'react-native-config'
 import { ExternalInvite, DeepLinkData } from '../Models/TextileTypes'
 
-
 function getParams (hash: string): { [key: string]: (string | string[]) } {
   const query = hash.replace('#', '')
   const vars = query.split('&').map((expression) => expression.split('='))

--- a/ios/TextilePhotos.xcodeproj/project.pbxproj
+++ b/ios/TextilePhotos.xcodeproj/project.pbxproj
@@ -1984,7 +1984,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.textile.Wallet;
+				PRODUCT_BUNDLE_IDENTIFIER = io.textile.WalletDev;
 				PRODUCT_NAME = TextilePhotos;
 				PROVISIONING_PROFILE = "2db150d1-101b-4ac0-b886-3e69f53beb8a";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development io.textile.Wallet";

--- a/ios/TextilePhotos.xcodeproj/project.pbxproj
+++ b/ios/TextilePhotos.xcodeproj/project.pbxproj
@@ -1984,7 +1984,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.textile.WalletDev;
+				PRODUCT_BUNDLE_IDENTIFIER = io.textile.WalletDebug;
 				PRODUCT_NAME = TextilePhotos;
 				PROVISIONING_PROFILE = "2db150d1-101b-4ac0-b886-3e69f53beb8a";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development io.textile.Wallet";

--- a/ios/TextilePhotos.xcodeproj/project.pbxproj
+++ b/ios/TextilePhotos.xcodeproj/project.pbxproj
@@ -1987,7 +1987,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = io.textile.WalletDebug;
 				PRODUCT_NAME = TextilePhotos;
 				PROVISIONING_PROFILE = "2db150d1-101b-4ac0-b886-3e69f53beb8a";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development io.textile.Wallet";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.textile.WalletDebug";
 				VALID_ARCHS = "arm64 armv7s";
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/yarn.lock
+++ b/yarn.lock
@@ -435,7 +435,7 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-"@textile/go-mobile@^0.1.9":
+"@textile/go-mobile@0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-0.1.9.tgz#7bcf39cb2f95dd200afb6ff45f1cdc6bde972cee"
 


### PR DESCRIPTION
![screen shot 2018-09-17 at 5 12 40 pm](https://user-images.githubusercontent.com/370259/45657032-8ba0c080-ba9d-11e8-8f9a-6e1494a3d3e2.png)
 
just changes this ^, but ended up going with WalletDebug so in fabric the nomenclature matched

allows side-by-side installs on your device