### PR TITLE
removes tour overlay in Threads view

### DIFF
--- a/App/Containers/ThreadsList.js
+++ b/App/Containers/ThreadsList.js
@@ -78,8 +78,8 @@ class ThreadsList extends React.PureComponent {
       onTour: this.props.showOnboarding === true,
       toggleVerboseUi: this.props.toggleVerboseUi,
       completeTour: () => {
-        console.log('clearing threads')
-        this.props.completeScreen('threads') }
+        this.props.completeScreen('threads')
+      }
     })
   }
 
@@ -248,7 +248,6 @@ const mapStateToProps = (state) => {
       .sort((a, b) => a.updated < b.updated)
   }
 
-  console.log(state.preferences.tourScreens.threads)
   return {
     profile,
     threads,


### PR DESCRIPTION
![screen shot 2018-09-20 at 1 39 06 pm](https://user-images.githubusercontent.com/370259/45845659-92684700-bcda-11e8-9ffb-58bead78bff9.png)

Removing that overlay in favor of the inline onboarding that we had.