### PR TITLE
Adds auto verify to android deeplinks

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
-        <intent-filter>
+        <intent-filter android:autoVerify="true">
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
I missed this from Android on first time around,

https://developer.android.com/training/app-links/verify-site-associations

it's a way to verify that our domain is owned by the same people who create the app (same as ios associated links verification). it means that instead of getting a list of viable apps to open the link in android it should open directly, which should help out android based invites a lot