### PR TITLE
Sourcemaps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,6 +207,9 @@ jobs:
                 command: bundle exec fastlane beta
                 working_directory: android
 
+            - store_artifacts:
+                path: ./android/sourcemap.js
+
     ios:
         macos:
             xcode: "9.4.0"
@@ -364,6 +367,9 @@ jobs:
 
             - store_artifacts:
                 path: ./ios/TextilePhotos.ipa
+
+            - store_artifacts:
+                path: ./ios/sourcemap.js
 
 workflows:
     version: 2

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -93,7 +93,8 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: "index.js"
+    entryFile: "index.js",
+    extraPackagerArgs: [ "--sourcemap-output", file("$buildDir/../../sourcemap.js")]
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"

--- a/ios/TextilePhotos.xcodeproj/project.pbxproj
+++ b/ios/TextilePhotos.xcodeproj/project.pbxproj
@@ -1953,6 +1953,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = 5VHA5U5FY8;
 				ENABLE_BITCODE = NO;
+				EXTRA_PACKAGER_ARGS = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",
@@ -2004,6 +2005,7 @@
 				CURRENT_PROJECT_VERSION = 5;
 				DEVELOPMENT_TEAM = 5VHA5U5FY8;
 				ENABLE_BITCODE = NO;
+				EXTRA_PACKAGER_ARGS = "--sourcemap-output $(PROJECT_DIR)/sourcemap.js";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)",


### PR DESCRIPTION
Generate and archive sourcemaps for iOS and Android builds. These can be used to get more information from JS stack traces.