### PR TITLE
Micro delay before nav

### DIFF
--- a/App/Sagas/NotificationsSagas.ts
+++ b/App/Sagas/NotificationsSagas.ts
@@ -55,9 +55,10 @@ export function * handleNewNotification (action: ActionType<typeof Notifications
 
 export function * handleEngagement (action: ActionType<typeof NotificationsActions.notificationEngagement>) {
   // Deals with the Engagement response from clicking a native notification
-  const { data } = action.payload.engagement
+  const data: any = action.payload.engagement.data
   try {
     if (!data || !data.hasOwnProperty('notification')) { return }
+    yield call(delay, 250)
     yield put(NotificationsActions.notificationSuccess(data.notification))
   } catch (error) {
     // Nothing to do


### PR DESCRIPTION
Not sure why... probably worth a deeper look someday. But if you come out of a background state, notification clicks seem to dead end. But if I put this small delay in, they seem to navigate properly. 

That's probably why they work sometimes, the app is already warm when you click them 