### PR TITLE
iPhone X fixes

### DIFF
--- a/App/Components/KeyboardResponsiveContainer.tsx
+++ b/App/Components/KeyboardResponsiveContainer.tsx
@@ -26,30 +26,36 @@ export default class KeyboardResponsiveContainer extends React.Component<Props, 
   }
 
   keyboardWillChangeFrame = (event: any) => {
-    LayoutAnimation.configureNext(LayoutAnimation.create(
-      event.duration,
-      LayoutAnimation.Types[event.easing]
-    ))
+    LayoutAnimation.configureNext({
+      duration: event.duration,
+      update: {
+        type: LayoutAnimation.Types[event.easing]
+      }
+    })
     this.setState({
         height: this.bottomViewY - event.endCoordinates.screenY
     })
   }
 
   keyboardWillAppear = (event: any) => {
-    LayoutAnimation.configureNext(LayoutAnimation.create(
-      event.duration,
-      LayoutAnimation.Types[event.easing]
-    ))
+    LayoutAnimation.configureNext({
+      duration: event.duration,
+      update: {
+        type: LayoutAnimation.Types[event.easing]
+      }
+    })
     this.setState({
         height: this.bottomViewY - event.endCoordinates.screenY
     })
   }
 
   keyboardWillHide = (event: any) => {
-    LayoutAnimation.configureNext(LayoutAnimation.create(
-      event.duration,
-      LayoutAnimation.Types[event.easing]
-    ))
+    LayoutAnimation.configureNext({
+      duration: event.duration,
+      update: {
+        type: LayoutAnimation.Types[event.easing]
+      }
+    })
     this.setState({
         height: 0
     })

--- a/App/Containers/Comments.tsx
+++ b/App/Containers/Comments.tsx
@@ -2,7 +2,7 @@ import React, {Component} from 'react'
 import { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import { View, ScrollView } from 'react-native'
-import { NavigationActions } from 'react-navigation'
+import { NavigationActions, SafeAreaView } from 'react-navigation'
 
 import { TextileHeaderButtons, Item } from '../Components/HeaderButtons'
 
@@ -60,19 +60,21 @@ class Comments extends Component<Props> {
 
   render () {
     return (
-      <KeyboardResponsiveContainer style={styles.container} >
-        {this.props.captionCommentCardProps &&
-          <CommentCard {...this.props.captionCommentCardProps} />
-        }
-        <ScrollView ref={(ref) => this.scrollView = ref ? ref : undefined} style={styles.contentContainer}>
-          <View>
-            {this.props.commentCardProps.map((commentCardProps, i) => (
-              <CommentCard key={i} {...commentCardProps} />
-            ))}
-          </View>
-        </ScrollView>
-        <CommentBox onUpdate={this.props.updateComment} onSubmit={this.props.submitComment} value={this.props.commentValue} />
-      </KeyboardResponsiveContainer>
+      <SafeAreaView style={styles.safeContainer}>
+        <KeyboardResponsiveContainer style={styles.container}>
+          {this.props.captionCommentCardProps &&
+            <CommentCard {...this.props.captionCommentCardProps} />
+          }
+          <ScrollView ref={(ref) => this.scrollView = ref ? ref : undefined} style={styles.contentContainer}>
+            <View>
+              {this.props.commentCardProps.map((commentCardProps, i) => (
+                <CommentCard key={i} {...commentCardProps} />
+              ))}
+            </View>
+          </ScrollView>
+          <CommentBox onUpdate={this.props.updateComment} onSubmit={this.props.submitComment} value={this.props.commentValue} />
+        </KeyboardResponsiveContainer>
+      </SafeAreaView>
     )
   }
 }

--- a/App/Containers/Styles/CommentsStyle.ts
+++ b/App/Containers/Styles/CommentsStyle.ts
@@ -1,6 +1,10 @@
 import { StyleSheet } from 'react-native'
 
 export default StyleSheet.create({
+  safeContainer: {
+    backgroundColor: '#FFFFFF',
+    flex: 1
+  },
   container: {
     marginTop: 0, // <- Removed until header gets reworked, orig = 20
     backgroundColor: '#FAFCFE',

--- a/App/SB/views/OnBoarding/index.js
+++ b/App/SB/views/OnBoarding/index.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import { Text, Image, View } from 'react-native'
+import { SafeAreaView } from 'react-navigation'
 
 import Footer from './Footer'
 import styles from './statics/styles'
@@ -26,29 +27,33 @@ export default class OnBoarding extends Component {
 
     return (
       <Fragment>
-        <View style={styles.onBoardingContainer}>
-          {pages.map(page => (
-            <Fragment key={page.image}>
-              {page.order === step &&
-                <Fragment>
-                  <View style={styles.imageContainer}>
-                    <Image source={page.image} />
-                  </View>
-                  <View style={styles.titleContainer}>
-                    <Text style={styles.title}>{page.title}</Text>
-                  </View>
-                  <Text style={styles.subtitle}>{page.subTitle}</Text>
-                </Fragment>}
-            </Fragment>
-          ))}
-        </View>
-        <Footer
-          currentPageIndex={step}
-          pages={pages}
-          onNext={this.onNext}
-          onSkip={this.onSubmit}
-          onSubmit={this.onSubmit}
-        />
+        <SafeAreaView style={styles.safeContainerTop} />
+        <SafeAreaView style={styles.safeContainerBottom}>
+          <View style={styles.onBoardingContainer}>
+            {pages.map(page => (
+              <Fragment key={page.image}>
+                {page.order === step &&
+                  <Fragment>
+                    <View style={styles.imageContainer}>
+                      <Image source={page.image} />
+                    </View>
+                    <View style={styles.titleContainer}>
+                      <Text style={styles.title}>{page.title}</Text>
+                    </View>
+                    <Text style={styles.subtitle}>{page.subTitle}</Text>
+                  </Fragment>}
+              </Fragment>
+            ))}
+          </View>
+          <Footer
+            currentPageIndex={step}
+            pages={pages}
+            onNext={this.onNext}
+            onSkip={this.onSubmit}
+            onSubmit={this.onSubmit}
+          />
+        </SafeAreaView>
+
       </Fragment>
     )
   }

--- a/App/SB/views/OnBoarding/statics/styles.js
+++ b/App/SB/views/OnBoarding/statics/styles.js
@@ -2,6 +2,13 @@ import { StyleSheet } from 'react-native'
 import { BentonSansBold } from '../../../util/fonts'
 
 export default StyleSheet.create({
+  safeContainerTop: {
+    backgroundColor: '#FAFCFE'
+  },
+  safeContainerBottom: {
+    flex: 1,
+    backgroundColor: 'white'
+  },
   onBoardingContainer: {
     paddingTop: 115,
     paddingHorizontal: 20,

--- a/App/SB/views/ThreadsEditFriends/index.js
+++ b/App/SB/views/ThreadsEditFriends/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { View, Text } from 'react-native'
 import { connect } from 'react-redux'
-import { NavigationActions } from 'react-navigation'
+import { NavigationActions, SafeAreaView } from 'react-navigation'
 import Toast from 'react-native-easy-toast'
 
 import ContactSelect from '../../components/ContactSelect'
@@ -97,7 +97,7 @@ class ThreadsEditFriends extends React.PureComponent {
 
   render () {
     return (
-      <View style={styles.container}>
+      <SafeAreaView style={styles.container}>
         <ContactSelect
           getPublicLink={this._getPublicLink.bind(this)}
           contacts={this.props.contacts}
@@ -107,7 +107,7 @@ class ThreadsEditFriends extends React.PureComponent {
           notInThread={this.props.notInThread}
         />
         <Toast ref='toast' position='top' fadeInDuration={50} style={styles.toast} textStyle={styles.toastText} />
-      </View>
+      </SafeAreaView>
     )
   }
 }

--- a/App/SB/views/ThreadsEditFriends/statics/styles.js
+++ b/App/SB/views/ThreadsEditFriends/statics/styles.js
@@ -10,7 +10,7 @@ export default StyleSheet.create({
     fontSize: 18
   },
   container: {
-    backgroundColor: '#FAFCFE',
+    backgroundColor: 'white',
     flex: 1
   },
   contentContainer: {


### PR DESCRIPTION
Use `SafeAreaView` in a few key places so padding is correct at top and bottom of the screen on iPhone Xish models:

1. Onboarding
2. Comments
3. Invite peers

There is also a layout issue for iPhone X with the sign up/in screens as well, but something wasn't straight forward about fixing it, so I bailed since we'll be getting rid of those screens soon with profiles coming.

@andrewxhill also mentioned a crash that happens in the sim sometimes when navigating back from the comments screen. Something about `Unsupported layout animation createConfig property (null)`. I tinkered around and realized that might also be a real crash for people that use hardware/bluetooth keyboards. This PR fixes that crash.