### PR TITLE
Node lifecycle fix

### DIFF
--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -83,7 +83,7 @@ function * backgroundTaskRace () {
     )
   })
   BackgroundTimer.stop()
-  BackgroundFetch.finish(BackgroundFetch.FetchResult.FETCH_RESULT_NEW_DATA)
+  BackgroundFetch.finish(BackgroundFetch.FETCH_RESULT_NEW_DATA)
 }
 
 function * stopNodeAfterDelay (ms: number) {

--- a/typings/react-native-background-fetch/index.d.ts
+++ b/typings/react-native-background-fetch/index.d.ts
@@ -9,21 +9,17 @@ declare module 'react-native-background-fetch' {
 
   export function configure(config: Configuration, callbackFn: () => void, failureFn: (error: any) => void): void
 
-  export enum Status {
-    STATUS_RESTRICTED = 0,
-    STATUS_DENIED = 1,
-    STATUS_AVAILABLE = 2
-  }
+  export const STATUS_RESTRICTED = 0
+  export const STATUS_DENIED = 1
+  export const STATUS_AVAILABLE = 2
 
-  export function status(callbackFn: (status: Status) => void): void
+  export function status(callbackFn: (status: number) => void): void
 
-  export enum FetchResult {
-    FETCH_RESULT_NEW_DATA = 0,
-    FETCH_RESULT_NO_DATA = 1,
-    FETCH_RESULT_FAILED = 2
-  }
+  export const FETCH_RESULT_NEW_DATA = 0
+  export const FETCH_RESULT_NO_DATA = 1
+  export const FETCH_RESULT_FAILED = 2
 
-  export function finish(fetchResult: FetchResult): void
+  export function finish(fetchResult: number): void
 
   export function start(successFn: () => void, failureFn: () => void): void
 


### PR DESCRIPTION
Correctly model `react-native-background-fetch` constants to avoid JS crash in node lifecycle.

This should fix the problems we've been seeing with node lifecycle.