### PR TITLE
Better handling of node creation and start

### DIFF
--- a/App/Redux/TextileNodeRedux.ts
+++ b/App/Redux/TextileNodeRedux.ts
@@ -7,6 +7,7 @@ const actions = {
   appStateChange: createAction('APP_STATE_CHANGE', (resolve) => {
     return (previousState: TextileAppStateStatus, newState: AppStateStatus) => resolve({ previousState, newState })
   }),
+  createNodeRequest: createAction('CREATE_NODE_REQUEST'),
   creatingNode: createAction('CREATING_NODE'),
   createNodeSuccess: createAction('CREATE_NODE_SUCCESS'),
   startingNode: createAction('STARTING_NODE'),

--- a/App/Sagas/index.ts
+++ b/App/Sagas/index.ts
@@ -20,7 +20,7 @@ import TriggersActions from '../Redux/TriggersRedux'
 
 import { startup } from './StartupSagas'
 
-import { manageNode, backgroundFetch, locationUpdate } from './NodeLifecycle'
+import { manageNode, handleCreateNodeRequest, backgroundFetch, locationUpdate } from './NodeLifecycle'
 import { onNodeCreated } from './NodeCreated'
 import { onNodeStarted } from './NodeStarted'
 import { onNodeOnline } from './NodeOnline'
@@ -106,6 +106,7 @@ import {
 export default function * root () {
   yield all([
     call(manageNode),
+    call(handleCreateNodeRequest),
     call(onNodeCreated),
     call(onNodeStarted),
     call(onNodeOnline),


### PR DESCRIPTION
I'm about 85% confident in this change. Let's see how it works.

Should fix the problem of the double default thread because it should assure that the node creation and startup sequence can't only be called once at a time.