### PR TITLE
Don't submit for review from ci

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -113,8 +113,7 @@ platform :ios do
     deliver(
       force: true,
       app_version: parts[1],
-      skip_app_version_update: false,
-      submit_for_review: true
+      skip_app_version_update: false
     )
   end
 


### PR DESCRIPTION
Seemed cool, is cool, but requires that the CI build wait for App Store Connect processing of the binary to finish. Sometimes it's quick, but sometimes it takes an indefinite and long period of time. Either way, we'd have to pay for the CI time, so not worth it.