### PR TITLE
Parameterize url scheme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,14 +559,12 @@ workflows:
                     branches:
                         only:
                             - master
-                            - asutula/parameterize-url-scheme
             - android-adhoc:
                 context: textile-mobile-beta
                 filters:
                     branches:
                         only:
                             - master
-                            - asutula/parameterize-url-scheme
     release-ios:
         jobs:
             - ios-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -559,12 +559,14 @@ workflows:
                     branches:
                         only:
                             - master
+                            - asutula/parameterize-url-scheme
             - android-adhoc:
                 context: textile-mobile-beta
                 filters:
                     branches:
                         only:
                             - master
+                            - asutula/parameterize-url-scheme
     release-ios:
         jobs:
             - ios-release:

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+RN_TEXTILE_CAFE_URI="https://a.cafe.url"
+RN_TEXTILE_CAFE_PIN_PATH="/a/pin/path"
+RN_TEMPORARY_REFERRAL="SOMETHING"
+RN_URL_SCHEME="textile-dev"

--- a/App/Sagas/DeepLinkSagas.ts
+++ b/App/Sagas/DeepLinkSagas.ts
@@ -53,7 +53,8 @@ export function * routeDeepLink (action: ActionType<typeof UIActions.routeDeepLi
   try {
     // convert url scheme to standard url for parsing
     const scheme = Config.RN_URL_SCHEME
-    const standardUrl = url.replace(scheme + '://textile.photos/', 'https://textile.photos/')
+    const regexp = new RegExp(scheme + '://(www.)?textile.photos/')
+    const standardUrl = url.replace(regexp, 'https://textile.photos/')
     const data = DeepLink.getData(standardUrl)
     if (data) {
       if (data.path === '/invites/device' && data.hash !== '') {

--- a/App/Sagas/DeepLinkSagas.ts
+++ b/App/Sagas/DeepLinkSagas.ts
@@ -13,6 +13,7 @@ import { call, put, select, take } from 'redux-saga/effects'
 import { delay } from 'redux-saga'
 import UIActions from '../Redux/UIRedux'
 import { ActionType, getType } from 'typesafe-actions'
+import Config from 'react-native-config'
 import DeepLink from '../Services/DeepLink'
 import NavigationService from '../Services/NavigationService'
 import {PreferencesSelectors} from '../Redux/PreferencesRedux'
@@ -51,7 +52,8 @@ export function * routeDeepLink (action: ActionType<typeof UIActions.routeDeepLi
   if (!url) { return }
   try {
     // convert url scheme to standard url for parsing
-    const standardUrl = url.replace('textile://textile.photos/', 'https://textile.photos/')
+    const scheme = Config.RN_URL_SCHEME
+    const standardUrl = url.replace(scheme + '://textile.photos/', 'https://textile.photos/')
     const data = DeepLink.getData(standardUrl)
     if (data) {
       if (data.path === '/invites/device' && data.hash !== '') {

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-android_versioning (0.4.0)
+    fastlane-plugin-find_replace_string (0.1.0)
     fastlane-plugin-update_android_strings (0.1.0)
       ox
     gh_inspector (1.1.3)
@@ -148,6 +149,7 @@ PLATFORMS
 DEPENDENCIES
   fastlane
   fastlane-plugin-android_versioning
+  fastlane-plugin-find_replace_string
   fastlane-plugin-update_android_strings
 
 BUNDLED WITH

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -129,6 +129,8 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
+        // Added for react-native-config per https://github.com/luggit/react-native-config#advanced-android-setup
+        resValue "string", "build_config_package", "com.textile"
     }
     splits {
         abi {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -27,7 +27,7 @@
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
-          <data android:scheme="textile" android:host="textile.photos"/>
+          <data android:scheme="textile-dev" android:host="textile.photos"/>
           <data android:scheme="https"
                 android:host="www.textile.photos"
                 android:pathPrefix="/invites" />

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -24,11 +24,11 @@ lane :prep_release do
   # update ios indentifier
   update_app_identifier(
     xcodeproj: "./ios/#{project_name}.xcodeproj",
-    plist_path: "./ios/#{project_name}/Info.plist",
+    plist_path: "#{project_name}/Info.plist",
     app_identifier: new_app_id
   )
   update_info_plist(
-    plist_path: "./ios/#{project_name}/Info.plist",
+    plist_path: "#{project_name}/Info.plist",
     xcodeproj: "./ios/#{project_name}.xcodeproj",
     display_name: display_name,
     app_identifier: new_app_id

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,10 +8,9 @@ desc "Updates the app identifier, display name for dev, adhoc, and production re
 lane :prep_release do
   # beta, production
   type = ENV['RN_RELEASE_TYPE'] || 'production'
-  puts "Type: #{type}"
   suffix = ENV['RN_BUNDLE_SUFFIX'] || type
   suffix = suffix.length > 0 ? ".#{suffix}" : suffix
-  puts "Suffix: #{suffix}"
+  scheme = ENV['RN_URL_SCHEME'] || 'textile'
 
   # assumes identifier is defined in Appfile
   app_id = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
@@ -25,11 +24,11 @@ lane :prep_release do
   # update ios indentifier
   update_app_identifier(
     xcodeproj: "./ios/#{project_name}.xcodeproj",
-    plist_path: "#{project_name}/Info.plist",
+    plist_path: "./ios/#{project_name}/Info.plist",
     app_identifier: new_app_id
   )
   update_info_plist(
-    plist_path: "#{project_name}/Info.plist",
+    plist_path: "./ios/#{project_name}/Info.plist",
     xcodeproj: "./ios/#{project_name}.xcodeproj",
     display_name: display_name,
     app_identifier: new_app_id
@@ -49,4 +48,16 @@ lane :prep_release do
     }
   )
 
+  # update ios url scheme
+  update_url_schemes(
+    path: "./ios/#{project_name}/Info.plist",
+    url_schemes: ["#{scheme}"]
+  )
+
+  # update android url scheme
+  find_replace_string(
+    path_to_file: "./android/app/src/main/AndroidManifest.xml",
+    old_string: "textile-dev",
+    new_string: "#{scheme}"
+  )
 end

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -4,3 +4,4 @@
 
 gem 'fastlane-plugin-android_versioning'
 gem 'fastlane-plugin-update_android_strings'
+gem 'fastlane-plugin-find_replace_string'

--- a/ios/Textile/Info.plist
+++ b/ios/Textile/Info.plist
@@ -29,7 +29,7 @@
 			<string>io.textile.Wallet</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>textile</string>
+				<string>textile-dev</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
Defaults to `textile-dev://`, updated in env specific builds on CircleCI. Schemes are as follows:
 
- production: `textile`
- beta: `textile-beta`
- dev: `textile-dev`

So, when you have an invite URL, you can choose with version of the app to open it with by editing the URL scheme accordingly.

Made an update where you can have a url with or without `www.` in it (important because our web page redirects to `www.textile.photos` then you may copy that url.