### PR TITLE
making the radio button a touch target for the thread select screen

### DIFF
--- a/App/SB/components/RadioButton/index.js
+++ b/App/SB/components/RadioButton/index.js
@@ -1,21 +1,17 @@
 import React from 'react'
-import { View, TouchableOpacity, Image } from 'react-native'
+import { View, Image } from 'react-native'
 
 import styles from './statics/styles'
 
 const RadioButton = props => {
-  const { selected, style, disabled, onPress } = props
+  const { selected, style, disabled } = props
 
   return (
-    <TouchableOpacity style={[styles.button, style, disabled && styles.disabled]} onPress={onPress}>
+    <View style={[styles.button, style, disabled && styles.disabled]}>
       { selected && <Image style={styles.buttonImage} source={require('./statics/check.png')} /> }
       { selected && <View style={[styles.buttonSelected, disabled && styles.buttonDisabled]} /> }
-    </TouchableOpacity>
+    </View>
   )
-}
-
-RadioButton.defaultProps = {
-	onPress: () => {},
 }
 
 export default RadioButton

--- a/App/SB/components/RadioButton/index.js
+++ b/App/SB/components/RadioButton/index.js
@@ -4,14 +4,18 @@ import { View, TouchableOpacity, Image } from 'react-native'
 import styles from './statics/styles'
 
 const RadioButton = props => {
-  const { selected, style, disabled } = props
+  const { selected, style, disabled, onPress } = props
 
   return (
-    <TouchableOpacity style={[styles.button, style, disabled && styles.disabled]}>
+    <TouchableOpacity style={[styles.button, style, disabled && styles.disabled]} onPress={onPress}>
       { selected && <Image style={styles.buttonImage} source={require('./statics/check.png')} /> }
       { selected && <View style={[styles.buttonSelected, disabled && styles.buttonDisabled]} /> }
     </TouchableOpacity>
   )
+}
+
+RadioButton.defaultProps = {
+	onPress: () => {},
 }
 
 export default RadioButton

--- a/App/SB/components/ThreadSelect/ThreadSelectCard.tsx
+++ b/App/SB/components/ThreadSelect/ThreadSelectCard.tsx
@@ -25,23 +25,21 @@ interface ScreenProps {
 type Props = StateProps & ScreenProps
 
 class ThreadSelectCard extends Component<Props> {
-  _onPress() {
-    if (this.props.onSelect) {
-      this.props.onSelect(this.props.thread.id)
-    }
-  }
-
   render () {
     return (
       <TouchableOpacity
         activeOpacity={!this.props.onSelect ? 1.0 : 0.6}
         style={styles.threadItem}
         /* tslint:disable-next-line */
-        onPress={this._onPress.bind(this)}
+        onPress={() => {
+          if (this.props.onSelect) {
+            this.props.onSelect(this.props.thread.id)
+          }
+        }}
       >
         <PhotoWithTextBox text={this.props.thread.name} photo={this.props.thumb} />
         <View style={styles.threadSelectRadio}>
-          <RadioButton selected={this.props.selected} disabled={this.props.disabled} onPress={this._onPress.bind(this)} />
+          <RadioButton selected={this.props.selected} disabled={this.props.disabled}/>
         </View>
       </TouchableOpacity>
     )

--- a/App/SB/components/ThreadSelect/ThreadSelectCard.tsx
+++ b/App/SB/components/ThreadSelect/ThreadSelectCard.tsx
@@ -25,21 +25,23 @@ interface ScreenProps {
 type Props = StateProps & ScreenProps
 
 class ThreadSelectCard extends Component<Props> {
+  _onPress() {
+    if (this.props.onSelect) {
+      this.props.onSelect(this.props.thread.id)
+    }
+  }
+
   render () {
     return (
       <TouchableOpacity
         activeOpacity={!this.props.onSelect ? 1.0 : 0.6}
         style={styles.threadItem}
         /* tslint:disable-next-line */
-        onPress={() => {
-          if (this.props.onSelect) {
-            this.props.onSelect(this.props.thread.id)
-          }
-        }}
+        onPress={this._onPress.bind(this)}
       >
         <PhotoWithTextBox text={this.props.thread.name} photo={this.props.thumb} />
         <View style={styles.threadSelectRadio}>
-          <RadioButton selected={this.props.selected} disabled={this.props.disabled}/>
+          <RadioButton selected={this.props.selected} disabled={this.props.disabled} onPress={this._onPress.bind(this)} />
         </View>
       </TouchableOpacity>
     )


### PR DESCRIPTION
textile is great! i've honestly waiting for something like this to bubble up and am excited to see how usable it is even for not p2p heads like me :)
this PR fixes something i ran into when initially poking around in the app, where tapping on the radio button in the "Thread select" view for an image wouldn't select the corresponding thread. hopefully uncontroversial, but let me know if there's anything i should do differently