### PR TITLE
Don't announce peer until we have all the needed data

### DIFF
--- a/App/Sagas/Migration.ts
+++ b/App/Sagas/Migration.ts
@@ -230,9 +230,11 @@ export function * runRecurringMigrationTasks () {
     if (announcement && announcement.status === 'pending') {
       const { currentPeerId, currentAddress, previousUsername, previousPeerId } = announcement.peerDetails
       try {
-        yield call(announceId, currentPeerId, previousPeerId, currentAddress, previousUsername)
-        // If no error, mark as successful
-        yield put(MigrationActions.peerAnnouncementSuccess())
+        if (currentPeerId && previousPeerId && currentAddress) {
+          yield call(announceId, currentPeerId, previousPeerId, currentAddress, previousUsername)
+          // If no error, mark as successful
+          yield put(MigrationActions.peerAnnouncementSuccess())
+        }
       } catch (error) {
         // just run again later
       }


### PR DESCRIPTION
This wasn't stopping the peer id migration from working (the missing env item on the ci server was), but this was causing a confusing error.