### PR TITLE
Update to rc21

### DIFF
--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -175,8 +175,8 @@ function * discoverAndRegisterCafes() {
   if (onlineTimout) {
     throw new Error('node online timed out, internet connection needed')
   }
-  yield call(registerCafe, discoveredCafes.primary.peer)
-  yield call(registerCafe, discoveredCafes.secondary.peer)
+  yield call(registerCafe, discoveredCafes.primary.url)
+  yield call(registerCafe, discoveredCafes.secondary.url)
 }
 
 interface DiscoveredCafe {
@@ -185,6 +185,7 @@ interface DiscoveredCafe {
   readonly api: string
   readonly protocol: string
   readonly node: string
+  readonly url: string
 }
 interface DiscoveredCafes {
   readonly primary: DiscoveredCafe

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint -c tslint.json --project ."
   },
   "dependencies": {
-    "@textile/go-mobile": "1.0.0-rc20",
+    "@textile/go-mobile": "1.0.0-rc21",
     "buffer": "^5.2.1",
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,9 +610,9 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@textile/go-mobile@1.0.0-rc20":
-  version "1.0.0-rc20"
-  resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-1.0.0-rc20.tgz#cf18eb52b75e022b9e5d906902fb9ecce4207871"
+"@textile/go-mobile@1.0.0-rc21":
+  version "1.0.0-rc21"
+  resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-1.0.0-rc21.tgz#6f942c7b8c45c79fb7f195a839fd796dc6d10f6a"
 
 "@types/cheerio@*":
   version "0.22.9"


### PR DESCRIPTION
Updates to sending the cafe url during the registration process. Interestingly, if I call `registerCafe` immediately after the call to `start` returns, I get an EXC_BAD_ACCESS from inside the go layer. I kept trying a increasing delay before calling `registerCafe` and kept getting the crash until the delay was around 2 seconds, which is also about when the node comes "online". So I left the "wait until online" logic in there for now and that seems solid. @sanderpick let me know if you want to dig into that any more.