### PR TITLE
textile-go: update to v1.0.0-rc22

### DIFF
--- a/App/NativeModules/Textile/Model.ts
+++ b/App/NativeModules/Textile/Model.ts
@@ -85,21 +85,31 @@ export interface ExternalInvite {
   readonly inviter: string
 }
 
+export interface Cafe {
+  readonly peer: string
+  readonly address: string
+  readonly api: string
+  readonly protocol: string
+  readonly node: string
+  readonly url: string
+  readonly swarm: ReadonlyArray<string>
+}
+
 export interface CafeSession {
-  readonly cafe_id: string
+  readonly id: string
   readonly access: string
   readonly refresh: string
   readonly expiry: string
-  readonly http_addr: string
-  readonly swarm_addrs: ReadonlyArray<string>
+  readonly cafe: Cafe
 }
 
 export interface ContactInfo {
   readonly id: string
   readonly address: string
   readonly username: string
-  readonly thread_ids: ReadonlyArray<string>
+  readonly inboxes: ReadonlyArray<Cafe>
   readonly added: string
+  readonly thread_ids: ReadonlyArray<string>
 }
 
 export enum NotificationType {

--- a/App/Sagas/Account/AccountSagas.ts
+++ b/App/Sagas/Account/AccountSagas.ts
@@ -78,7 +78,7 @@ export function * refreshCafeSessions () {
     try {
       yield take(getType(AccountActions.refreshCafeSessionsRequest))
       const sessions: ReadonlyArray<CafeSession> = yield call(cafeSessions)
-      const effects = sessions.map((session) => call(refreshCafeSession, session.cafe_id))
+      const effects = sessions.map((session) => call(refreshCafeSession, session.id))
       const refreshedSessions: ReadonlyArray<CafeSession> = yield all(effects)
       yield put(AccountActions.cafeSessionsSuccess(refreshedSessions))
     } catch (error) {

--- a/App/Sagas/Migration.ts
+++ b/App/Sagas/Migration.ts
@@ -309,7 +309,7 @@ function * uploadPhoto(photoId: string, path: string, dispatch: Dispatch) {
     const filename = path.split('/').pop()!
     const session: CafeSession = yield call(getSession)
     const options: FS.UploadFileOptions = {
-      toUrl: `${session.http_addr}${Config.RN_TEXTILE_CAFE_API_PIN_PATH}`,
+      toUrl: `${session.cafe.url}${Config.RN_TEXTILE_CAFE_API_PIN_PATH}`,
       files: [{
         name: filename,
         filename,

--- a/App/Sagas/UploadFile.ts
+++ b/App/Sagas/UploadFile.ts
@@ -15,7 +15,7 @@ export function * uploadFile (id: string, payloadPath: string) {
     {
       customUploadId: id,
       path: payloadPath,
-      url: `${session.http_addr}${Config.RN_TEXTILE_CAFE_API_PIN_PATH}`,
+      url: `${session.cafe.url}${Config.RN_TEXTILE_CAFE_API_PIN_PATH}`,
       method: 'POST',
       type: 'raw',
       headers: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "tslint -c tslint.json --project ."
   },
   "dependencies": {
-    "@textile/go-mobile": "1.0.0-rc21",
+    "@textile/go-mobile": "1.0.0-rc22",
     "buffer": "^5.2.1",
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -610,9 +610,10 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@textile/go-mobile@1.0.0-rc21":
-  version "1.0.0-rc21"
-  resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-1.0.0-rc21.tgz#6f942c7b8c45c79fb7f195a839fd796dc6d10f6a"
+"@textile/go-mobile@1.0.0-rc22":
+  version "1.0.0-rc22"
+  resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-1.0.0-rc22.tgz#221f68de3500be453e074b433b5177c1c5ed9ba4"
+  integrity sha512-ugsnkDh0b3hHVYnTfSPJcxURvWsbMUA5RGGkq7wsY4S3ZijBvzB5Bb8gWfJDOeD4t363lkTd7/8eHsSJkbTkxg==
 
 "@types/cheerio@*":
   version "0.22.9"


### PR DESCRIPTION
- Updates a couple object models 
- Removes the "online" requirement from cafe registration