### PR TITLE
Particularly handy to have while we are testing

### DIFF
--- a/App/Components/InviteContactModal.tsx
+++ b/App/Components/InviteContactModal.tsx
@@ -24,7 +24,6 @@ import styles from './Styles/InviteContactModalStyles'
 
 interface DispatchProps {
   completeScreen: (threadName: string) => void
-  refreshContacts: () => void
   submit: (name: string, navigate: boolean, selectToShare: boolean) => void
 }
 
@@ -82,7 +81,6 @@ class InviteContactModal extends React.Component<DispatchProps & StateProps & Sc
 
   continue () {
     return () => {
-      this.props.refreshContacts()
       this.setState({threadSelected: true})
     }
   }
@@ -184,7 +182,6 @@ const mapStateToProps = (state: RootState): StateProps  => {
 const mapDispatchToProps = (dispatch: Dispatch<RootAction>): DispatchProps => {
   return {
     completeScreen: () => { dispatch(PreferencesActions.completeTourSuccess('threadsManager' as TourScreens)) },
-    refreshContacts: () => { dispatch(ContactsActions.getContactsRequest()) },
     submit: (name, navigate, selectToShare) => { dispatch(PhotoViewingActions.addThreadRequest(name, { navigate, selectToShare })) }
   }
 }

--- a/App/Services/EventHandlers/TextileNodeEventHandler.ts
+++ b/App/Services/EventHandlers/TextileNodeEventHandler.ts
@@ -8,6 +8,7 @@ import { RootState } from '../../Redux/Types'
 import TextileNodeActions from '../../Redux/TextileNodeRedux'
 import NotificationActions from '../../Redux/NotificationsRedux'
 import PhotoViewingActions from '../../Redux/PhotoViewingRedux'
+import ContactsActions from '../../Redux/ContactsRedux'
 import DeviceLogsActions from '../../Redux/DeviceLogsRedux'
 import StorageActions from '../../Redux/StorageRedux'
 import { toTypedNotification } from '../Notifications'
@@ -35,7 +36,7 @@ export default class TextileNodeEventHandler {
         type === BlockType.IGNORE) {
         this.store.dispatch(PhotoViewingActions.refreshThreadRequest(update.thread_id))
       } else if (type === BlockType.JOIN) {
-
+        this.store.dispatch(ContactsActions.getContactsRequest())
       }
       // create a local log line for the threadUpdate event
       const name = update.thread_name || update.thread_id

--- a/App/Services/EventHandlers/TextileNodeEventHandler.ts
+++ b/App/Services/EventHandlers/TextileNodeEventHandler.ts
@@ -36,6 +36,8 @@ export default class TextileNodeEventHandler {
         type === BlockType.IGNORE) {
         this.store.dispatch(PhotoViewingActions.refreshThreadRequest(update.thread_id))
       } else if (type === BlockType.JOIN) {
+        // Every time the a JOIN block is detected, we should refresh our in-mem contact list
+        // Enhancement: compare the joiner id with known ids and skip the refresh if known.
         this.store.dispatch(ContactsActions.getContactsRequest())
       }
       // create a local log line for the threadUpdate event

--- a/App/Services/EventHandlers/TextileNodeEventHandler.ts
+++ b/App/Services/EventHandlers/TextileNodeEventHandler.ts
@@ -34,6 +34,8 @@ export default class TextileNodeEventHandler {
         type === BlockType.FILES ||
         type === BlockType.IGNORE) {
         this.store.dispatch(PhotoViewingActions.refreshThreadRequest(update.thread_id))
+      } else if (type === BlockType.JOIN) {
+
       }
       // create a local log line for the threadUpdate event
       const name = update.thread_name || update.thread_id

--- a/App/Services/Notifications.ts
+++ b/App/Services/Notifications.ts
@@ -141,13 +141,13 @@ export function toPayload(notification: Notification): INotificationsPayload {
     case(NotificationType.CommentAddedNotification): {
       const title =  notification.threadName
       const message = [actor, notification.body].join(' ')
-      const body = 'commented on your photo'
+      const body = 'commented on a photo' // todo: fix "a" vs "your"
       const feed = [actor, body, 'in', notification.threadName].join(' ')
       return { title, message, feed, typeString }
     }
     case(NotificationType.LikeAddedNotification): {
       const title = notification.threadName
-      const body = 'liked your photo'
+      const body = 'liked a photo' // todo: fix "a" vs "your"
       const message = [actor, body].join(' ')
       const feed = [actor, body, 'in', notification.threadName].join(' ')
       return { title, message, feed, typeString }

--- a/App/Services/__tests__/__snapshots__/Notifications.ts.snap
+++ b/App/Services/__tests__/__snapshots__/Notifications.ts.snap
@@ -13,7 +13,7 @@ Object {
 
 exports[`notifications toPayload should create CommentAddedNotification 1`] = `
 Object {
-  "feed": "mock test commented on your photo in Great Thread",
+  "feed": "mock test commented on a photo in Great Thread",
   "message": "mock test commented on a photo: a camel!",
   "title": "Great Thread",
   "typeString": "COMMENT_ADDED",
@@ -40,8 +40,8 @@ Object {
 
 exports[`notifications toPayload should create LikeAddedNotification 1`] = `
 Object {
-  "feed": "mock test liked your photo in Great Thread",
-  "message": "mock test liked your photo",
+  "feed": "mock test liked a photo in Great Thread",
+  "message": "mock test liked a photo",
   "title": "Great Thread",
   "typeString": "LIKE_ADDED",
 }


### PR DESCRIPTION
@sanderpick I think it now makes sense only to call .contacts() for a refresh in two cases,

1. Node startup.
2. JOIN block event

so i remove other cases of it happening. let me know if you see other reasons to do it