### PR TITLE
Clicking comment now goes to Photo Screen

### DIFF
--- a/App/Containers/PhotoScreen.tsx
+++ b/App/Containers/PhotoScreen.tsx
@@ -41,7 +41,7 @@ class PhotoScreen extends React.Component<StateProps & NavigationScreenProps<{}>
           item={{type: 'photo', photo: this.props.photo, threadId: this.props.threadId, threadName: this.props.threadName}}
           onComment={this.onComment}
           onLikes={this.onLikes}
-          recentCommentsCount={5}
+          recentCommentsCount={-1}
           maxLinesPerComment={5}
         />
       }

--- a/App/Containers/PhotoScreen.tsx
+++ b/App/Containers/PhotoScreen.tsx
@@ -41,7 +41,6 @@ class PhotoScreen extends React.Component<StateProps & NavigationScreenProps<{}>
           item={{type: 'photo', photo: this.props.photo, threadId: this.props.threadId, threadName: this.props.threadName}}
           onComment={this.onComment}
           onLikes={this.onLikes}
-          recentCommentsCount={-1}
           maxLinesPerComment={5}
         />
       }

--- a/App/SB/components/ThreadDetailCard/index.tsx
+++ b/App/SB/components/ThreadDetailCard/index.tsx
@@ -83,6 +83,7 @@ class ThreadDetailCard extends React.PureComponent<OwnProps & StateProps & Dispa
       onComment
     } = this.props
 
+    const recentCommentsCount = this.props.recentCommentsCount === -1 ? photo.comments.length : this.props.recentCommentsCount
     const { photo } = item
 
     const likeRow = this.renderLikes(isLiked, didLike, photo)
@@ -94,13 +95,13 @@ class ThreadDetailCard extends React.PureComponent<OwnProps & StateProps & Dispa
       caption = <Text>{''}</Text>
     }
 
-    const recentComments = photo.comments.slice(0, this.props.recentCommentsCount).reverse().map((comment, index) => {
+    const recentComments = photo.comments.slice(0, recentCommentsCount).reverse().map((comment, index) => {
       const username = comment.username || 'unknown'
       return <KeyValueText key={index} keyString={username as string} value={comment.body} numberOfLines={this.props.maxLinesPerComment} />
     })
 
     let commentCountDescription
-    if (photo.comments.length > this.props.recentCommentsCount) {
+    if (photo.comments.length > recentCommentsCount) {
       commentCountDescription = (
         <TouchableOpacity onPress={onComment} >
           <Text style={styles.commentCount}>See all {photo.comments.length} comments...</Text>

--- a/App/SB/components/ThreadDetailCard/index.tsx
+++ b/App/SB/components/ThreadDetailCard/index.tsx
@@ -19,10 +19,10 @@ const WIDTH = Dimensions.get('window').width
 
 interface OwnProps {
   item: {type: string, photo: ThreadFilesInfo, threadId?: string, threadName?: string}, // TODO make proper type now
-  recentCommentsCount: number,
   maxLinesPerComment: number,
   onComment: () => void
   onLikes: () => void
+  recentCommentsCount?: number,
   displayThread?: boolean
 }
 
@@ -84,7 +84,7 @@ class ThreadDetailCard extends React.PureComponent<OwnProps & StateProps & Dispa
     } = this.props
 
     const { photo } = item
-    const recentCommentsCount = this.props.recentCommentsCount === -1 ? photo.comments.length : this.props.recentCommentsCount
+    const recentCommentsCount = this.props.recentCommentsCount || photo.comments.length
 
     const likeRow = this.renderLikes(isLiked, didLike, photo)
 

--- a/App/SB/components/ThreadDetailCard/index.tsx
+++ b/App/SB/components/ThreadDetailCard/index.tsx
@@ -83,8 +83,8 @@ class ThreadDetailCard extends React.PureComponent<OwnProps & StateProps & Dispa
       onComment
     } = this.props
 
-    const recentCommentsCount = this.props.recentCommentsCount === -1 ? photo.comments.length : this.props.recentCommentsCount
     const { photo } = item
+    const recentCommentsCount = this.props.recentCommentsCount === -1 ? photo.comments.length : this.props.recentCommentsCount
 
     const likeRow = this.renderLikes(isLiked, didLike, photo)
 

--- a/App/Sagas/NotificationsSagas.ts
+++ b/App/Sagas/NotificationsSagas.ts
@@ -94,7 +94,7 @@ export function * notificationView (action: ActionType<typeof NotificationsActio
         if (threadData) {
           yield put(PhotoViewingAction.viewThread(threadData.id))
           yield put(PhotoViewingAction.viewPhoto(notification.target))
-          yield call(NavigationService.navigate, 'Comments')
+          yield call(NavigationService.navigate, 'PhotoScreen')
         }
         break
       }


### PR DESCRIPTION
Saw this again and just wanted to nip it.

Makes more sense, when you click a comment you want to see what the commented as well as what they commented on. 

Based it of @asutula's suggestion, just link into the PhotoScreen but don't limit the comment count.