### PR TITLE
Node logs screen

### DIFF
--- a/App/Components/NodeLogsScreen.tsx
+++ b/App/Components/NodeLogsScreen.tsx
@@ -1,0 +1,97 @@
+import React, { Component } from 'react'
+import { ScrollView, TextInput, Platform, Clipboard } from 'react-native'
+import FS, { exists } from 'react-native-fs'
+import { NavigationScreenProps} from 'react-navigation'
+import * as s from '../Themes/Constants'
+import { REPO_PATH } from '../Sagas/NodeLifecycle'
+import { TextileHeaderButtons, Item as TextileItem } from './HeaderButtons'
+
+const LOG_FILE_PATH = `${REPO_PATH}/logs/textile.log`
+
+interface NavProps {
+  refresh: () => void
+  copy: () => void
+}
+
+interface State {
+  logData?: string
+}
+
+export default class NodeLogsScreen  extends Component<NavigationScreenProps<NavProps>, State> {
+
+  static navigationOptions = ({ navigation }: NavigationScreenProps<NavProps>) => {
+    const refresh = navigation.getParam('refresh')
+    const copy = navigation.getParam('copy')
+    const goBack = () => navigation.goBack()
+    return {
+      headerTitle: 'Node Logs',
+      headerLeft: (
+        <TextileHeaderButtons left={true}>
+          <TextileItem title='Back' iconName='arrow-left' onPress={goBack} />
+        </TextileHeaderButtons>
+      ),
+      headerRight: ((
+        <TextileHeaderButtons>
+          <TextileItem title='Copy' iconName='clipboard-plus' onPress={copy} />
+          <TextileItem title='Refresh' iconName='refresh-ccw' onPress={refresh} />
+        </TextileHeaderButtons>
+      ))
+    }
+  }
+
+  state: State = {}
+
+  textInput?: TextInput
+  scrollView?: ScrollView
+
+  refreshLogData = async () => {
+    const extists = await FS.exists(LOG_FILE_PATH)
+    if (exists) {
+      const stats = await FS.stat(LOG_FILE_PATH)
+      const size = stats.size as unknown as number
+      const bytesToRead = 1024 * 300
+      const offset = size - bytesToRead
+      const contents = await FS.read(LOG_FILE_PATH, bytesToRead, offset, 'utf8')
+      this.setState({ logData: contents })
+    }
+  }
+
+  copyLogData = () => {
+    if (this.state.logData) {
+      Clipboard.setString(this.state.logData)
+    }
+  }
+
+  scrollToBottom = () => {
+    if (this.scrollView) {
+      this.scrollView!.scrollToEnd({animated: true})
+    }
+  }
+
+  componentWillMount() {
+    this.props.navigation.setParams({
+      refresh: this.refreshLogData,
+      copy: this.copyLogData
+    })
+    this.refreshLogData()
+  }
+
+  render() {
+    const font = Platform.OS === 'ios' ? 'Courier' : 'monospace'
+    return (
+      <ScrollView
+        ref={(ref) => { this.scrollView = ref ? ref : undefined }}
+        style={{ flex: 1, backgroundColor: s.COLOR_BACKGROUND_PRIMARY }}
+      >
+        <TextInput
+          ref={(ref) => { this.textInput = ref ? ref : undefined }}
+          style={{ flex: 1, fontFamily: font, fontSize: s.FONT_SIZE_SMALL, paddingHorizontal: s.MARGIN_EXTRA_SMALL, backgroundColor: s.COLOR_BACKGROUND_PRIMARY }}
+          editable={false}
+          value={this.state.logData}
+          multiline={true}
+          onContentSizeChange={this.scrollToBottom}
+        />
+      </ScrollView>
+    )
+  }
+}

--- a/App/Navigation/AppNavigation/Primary/index.ts
+++ b/App/Navigation/AppNavigation/Primary/index.ts
@@ -6,6 +6,7 @@ import Account from '../../../SB/views/UserProfile'
 import NotificationSettings from '../../../SB/views/Notifications'
 import Storage from '../../../SB/views/Storage'
 import DeviceLogs from '../../../SB/views/DeviceLogs'
+import NodeLogsScreen from '../../../Components/NodeLogsScreen'
 import RecoveryPhrase from '../../../SB/views/UserProfile/RecoveryPhrase'
 import SetAvatar from '../../../Containers/SetAvatar'
 
@@ -39,7 +40,8 @@ const nav = createStackNavigator(
 
     ThreadInvite: AcceptInviteScreen,
 
-    DeviceLogs
+    DeviceLogs,
+    NodeLogsScreen
   },
   {
     navigationOptions: {

--- a/App/SB/views/UserProfile/index.js
+++ b/App/SB/views/UserProfile/index.js
@@ -45,6 +45,9 @@ class UserProfile extends React.PureComponent {
   _deviceLogs () {
     this.props.navigation.navigate('DeviceLogs')
   }
+  _nodeLogs () {
+    this.props.navigation.navigate('NodeLogsScreen')
+  }
   _changeAvatar () {
     this.props.navigation.navigate('ChangeAvatar', { onSuccess: () => this.props.navigation.goBack() })
   }
@@ -108,6 +111,9 @@ class UserProfile extends React.PureComponent {
           </TouchableOpacity>}
           {this.props.verboseUi && <TouchableOpacity style={styles.listItem} onPress={this._deviceLogs.bind(this)}>
             <Text style={styles.listText}>Device Logs</Text>
+          </TouchableOpacity>}
+          {this.props.verboseUi && <TouchableOpacity style={styles.listItem} onPress={this._nodeLogs.bind(this)}>
+            <Text style={styles.listText}>Node Logs</Text>
           </TouchableOpacity>}
           <TouchableOpacity style={styles.listItem} onPress={this._changeAvatar.bind(this)}>
             <Text style={styles.listText}>Change Avatar</Text>

--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -143,7 +143,6 @@ function * createAndStartNode(dispatch: Dispatch): any {
         yield put(AccountActions.setRecoveryPhrase(recoveryPhrase))
         yield put(TextileNodeActions.derivingAccount())
         const walletAccount: WalletAccount = yield call(walletAccountAt, recoveryPhrase, 0)
-        const logToDisk = !__DEV__
         yield put(TextileNodeActions.initializingRepo())
         yield call(initRepo, walletAccount.seed, REPO_PATH, true)
         yield call(createAndStartNode, dispatch)

--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -145,7 +145,7 @@ function * createAndStartNode(dispatch: Dispatch): any {
         const walletAccount: WalletAccount = yield call(walletAccountAt, recoveryPhrase, 0)
         const logToDisk = !__DEV__
         yield put(TextileNodeActions.initializingRepo())
-        yield call(initRepo, walletAccount.seed, REPO_PATH, logToDisk)
+        yield call(initRepo, walletAccount.seed, REPO_PATH, true)
         yield call(createAndStartNode, dispatch)
       } else {
         yield put(TextileNodeActions.nodeError(error))

--- a/App/Themes/Constants.ts
+++ b/App/Themes/Constants.ts
@@ -25,6 +25,7 @@ export const FONT_LINE_HEIGHT_SMALL = 15
 export const FONT_LINE_HEIGHT_REGULAR = 18
 export const FONT_LINE_HEIGHT_MEDIUM = 24
 
+export const MARGIN_EXTRA_SMALL = 8
 export const MARGIN_SMALL = 16
 export const MARGIN_STANDARD = 20
 


### PR DESCRIPTION
Get's pretty brutal on memory usage to read in the whole log (can be many MB), so reading in the last 300KB for now. Provides refresh and copy to clipboard. Let's see how that feels.
<img width="559" alt="screen shot 2019-01-10 at 15 29 38" src="https://user-images.githubusercontent.com/528969/50998680-d1badd80-14ed-11e9-84c2-627791acf083.png">
