### PR TITLE
Android: avatar border radius fix

### DIFF
--- a/App/Components/Avatar.tsx
+++ b/App/Components/Avatar.tsx
@@ -74,14 +74,16 @@ class Avatar extends React.Component<Props, State> {
     if (isLocalUser && nodeStarted && localAvatar && widthNumber) {
       // Render TextileImage
       return (
-        <TextileImage
-          style={{ ...(this.props.style || {}), width, height, borderRadius: this.state.borderRadius }}
-          target={localAvatar}
-          index={0}
-          forMinWidth={widthNumber}
-          resizeMode={'cover'}
-          onLayout={this.onImageLayout}
-        />
+        <View style={{ width, height, borderRadius: this.state.borderRadius, overflow: 'hidden' }}>
+          <TextileImage
+            style={{ ...(this.props.style || {}), width, height, borderRadius: this.state.borderRadius }}
+            target={localAvatar}
+            index={0}
+            forMinWidth={widthNumber}
+            resizeMode={'cover'}
+            onLayout={this.onImageLayout}
+          />
+        </View>
       )
     } else if (uri) {
       const uniqueUserColor = !this.state.showIcon ? {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -124,8 +124,8 @@ android {
         applicationIdSuffix ".dev"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 0
-        versionName "0"
+        versionCode 1
+        versionName "1.0"
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Jan 16 05:37:12 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
- Adds a `View` wrapper to `TextileImage` the includes the border radius, `overflow: hidden` is also needed
- Updates android gradle plugin to latest (3.3.0), which requires gradle 4.10.1

fixes #837 