### PR TITLE
Fix proto CafeSession handling

### DIFF
--- a/App/Redux/AccountRedux.ts
+++ b/App/Redux/AccountRedux.ts
@@ -1,5 +1,6 @@
 import { createAction, ActionType, getType } from 'typesafe-actions'
-import { ContactInfo, CafeSession } from '@textile/react-native-sdk'
+import { ContactInfo } from '@textile/react-native-sdk'
+import { ICafeSessions } from '@textile/react-native-protobufs'
 
 const actions = {
   refreshProfileRequest: createAction('REFRESH_PROFILE_REQUEST'),
@@ -34,7 +35,7 @@ const actions = {
   getCafeSessionsRequest: createAction('GET_CAFE_SESSIONS_REQUEST'),
   refreshCafeSessionsRequest: createAction('REFRESH_CAFE_SESSIONS_REQUEST'),
   cafeSessionsSuccess: createAction('CAFE_SESSIONS_SUCCESS', (resolve) => {
-    return (sessions: ReadonlyArray<CafeSession>) => resolve({ sessions })
+    return (sessions: ICafeSessions) => resolve({ sessions })
   }),
   cafeSessionsError: createAction('CAFE_SESSIONS_ERROR', (resolve) => {
     return (error: any) => resolve({ error })
@@ -59,7 +60,7 @@ interface AccountState {
   }
   recoveryPhrase?: string,
   cafeSessions: {
-    sessions: ReadonlyArray<CafeSession>
+    sessions: ICafeSessions
     processing: boolean
     error?: string
   }
@@ -73,7 +74,9 @@ const initialState: AccountState = {
   avatar: {},
   cafeSessions: {
     processing: false,
-    sessions: []
+    sessions: {
+      values: []
+    }
   }
 }
 

--- a/App/Redux/AccountRedux.ts
+++ b/App/Redux/AccountRedux.ts
@@ -1,6 +1,6 @@
 import { createAction, ActionType, getType } from 'typesafe-actions'
 import { ContactInfo } from '@textile/react-native-sdk'
-import { ICafeSessions } from '@textile/react-native-protobufs'
+import { ICafeSession } from '@textile/react-native-protobufs'
 
 const actions = {
   refreshProfileRequest: createAction('REFRESH_PROFILE_REQUEST'),
@@ -35,7 +35,7 @@ const actions = {
   getCafeSessionsRequest: createAction('GET_CAFE_SESSIONS_REQUEST'),
   refreshCafeSessionsRequest: createAction('REFRESH_CAFE_SESSIONS_REQUEST'),
   cafeSessionsSuccess: createAction('CAFE_SESSIONS_SUCCESS', (resolve) => {
-    return (sessions: ICafeSessions) => resolve({ sessions })
+    return (sessions: ReadonlyArray<ICafeSession>) => resolve({ sessions })
   }),
   cafeSessionsError: createAction('CAFE_SESSIONS_ERROR', (resolve) => {
     return (error: any) => resolve({ error })
@@ -60,7 +60,7 @@ interface AccountState {
   }
   recoveryPhrase?: string,
   cafeSessions: {
-    sessions: ICafeSessions
+    sessions: ReadonlyArray<ICafeSession>
     processing: boolean
     error?: string
   }
@@ -74,9 +74,7 @@ const initialState: AccountState = {
   avatar: {},
   cafeSessions: {
     processing: false,
-    sessions: {
-      values: []
-    }
+    sessions: []
   }
 }
 

--- a/App/Redux/AccountSelectors.ts
+++ b/App/Redux/AccountSelectors.ts
@@ -1,4 +1,5 @@
 import { RootState } from './Types'
+import { ICafeSession } from '@textile/react-native-protobufs'
 
 /**
  * Returns the Account Address
@@ -20,15 +21,21 @@ export function getUsername (state: RootState): string | undefined {
 }
 
 export function bestSession(state: RootState) {
-  const allSessions = state.account.cafeSessions.sessions.values
-  if (allSessions && allSessions.length > 0) {
-    return allSessions[0]
+  const values = state.account.cafeSessions.sessions
+  if (values.length === 0) {
+    return
   }
-  // const sorted = allSessions.slice().sort((a, b) => {
-  //   const aExpiry = new Date(a.exp).getTime()
-  //   const bExpiry = new Date(b.exp).getTime()
-  //   return aExpiry - bExpiry
-  // })
-  // const newest = sorted.pop()
-  // return newest
+  const sorted = values.slice().sort((a, b) => {
+    const aExpiry = new Date(getSessionMillis(a)).getTime()
+    const bExpiry = new Date(getSessionMillis(b)).getTime()
+    return aExpiry - bExpiry
+  })
+  return sorted.pop()
+}
+
+export function getSessionMillis(session: ICafeSession): number {
+  if (!session.exp || !session.exp.seconds || !session.exp.nanos) {
+    return 0
+  }
+  return (session.exp.seconds as number) * 1e3 + session.exp.nanos / 1e6
 }

--- a/App/Redux/AccountSelectors.ts
+++ b/App/Redux/AccountSelectors.ts
@@ -20,12 +20,15 @@ export function getUsername (state: RootState): string | undefined {
 }
 
 export function bestSession(state: RootState) {
-  const allSessions = state.account.cafeSessions.sessions
-  const sorted = allSessions.slice().sort((a, b) => {
-    const aExpiry = new Date(a.exp).getTime()
-    const bExpiry = new Date(b.exp).getTime()
-    return aExpiry - bExpiry
-  })
-  const newest = sorted.pop()
-  return newest
+  const allSessions = state.account.cafeSessions.sessions.values
+  if (allSessions && allSessions.length > 0) {
+    return allSessions[0]
+  }
+  // const sorted = allSessions.slice().sort((a, b) => {
+  //   const aExpiry = new Date(a.exp).getTime()
+  //   const bExpiry = new Date(b.exp).getTime()
+  //   return aExpiry - bExpiry
+  // })
+  // const newest = sorted.pop()
+  // return newest
 }

--- a/App/Redux/AccountSelectors.ts
+++ b/App/Redux/AccountSelectors.ts
@@ -20,10 +20,10 @@ export function getUsername (state: RootState): string | undefined {
          state.account.profile.value.username
 }
 
-export function bestSession(state: RootState) {
+export function bestSession(state: RootState): ICafeSession | undefined {
   const values = state.account.cafeSessions.sessions
   if (values.length === 0) {
-    return
+    return undefined
   }
   const sorted = values.slice().sort((a, b) => {
     const aExpiry = new Date(getSessionMillis(a)).getTime()

--- a/App/Sagas/Account/AccountSagas.ts
+++ b/App/Sagas/Account/AccountSagas.ts
@@ -8,9 +8,9 @@ import {
   profile,
   setAvatar as updateAvatar,
   setUsername as username,
-  ContactInfo,
-  CafeSession
+  ContactInfo
 } from '@textile/react-native-sdk'
+import { ICafeSessions } from '@textile/react-native-protobufs'
 
 export function * refreshProfile () {
   while (true) {
@@ -65,7 +65,7 @@ export function * getCafeSessions () {
   while (true) {
     try {
       yield take(getType(AccountActions.getCafeSessionsRequest))
-      const sessions: ReadonlyArray<CafeSession> = yield call(cafeSessions)
+      const sessions: Readonly<ICafeSessions> = yield call(cafeSessions)
       yield put(AccountActions.cafeSessionsSuccess(sessions))
     } catch (error) {
       yield put(AccountActions.cafeSessionsError(error))
@@ -77,10 +77,11 @@ export function * refreshCafeSessions () {
   while (true) {
     try {
       yield take(getType(AccountActions.refreshCafeSessionsRequest))
-      const sessions: ReadonlyArray<CafeSession> = yield call(cafeSessions)
-      const effects = sessions.map((session) => call(refreshCafeSession, session.id))
-      const refreshedSessions: ReadonlyArray<CafeSession> = yield all(effects)
-      yield put(AccountActions.cafeSessionsSuccess(refreshedSessions))
+      const sessions: Readonly<ICafeSessions> = yield call(cafeSessions)
+      yield put(AccountActions.cafeSessionsSuccess(sessions))
+      // const effects = sessions.map((session) => call(refreshCafeSession, session.id))
+      // const refreshedSessions: ReadonlyArray<CafeSession> = yield all(effects)
+      // yield put(AccountActions.cafeSessionsSuccess(refreshedSessions))
     } catch (error) {
       yield put(AccountActions.cafeSessionsError(error))
     }

--- a/App/Sagas/Account/AccountSagas.ts
+++ b/App/Sagas/Account/AccountSagas.ts
@@ -10,7 +10,7 @@ import {
   setUsername as username,
   ContactInfo
 } from '@textile/react-native-sdk'
-import { ICafeSessions } from '@textile/react-native-protobufs'
+import { ICafeSession, ICafeSessions } from '@textile/react-native-protobufs'
 
 export function * refreshProfile () {
   while (true) {
@@ -65,8 +65,13 @@ export function * getCafeSessions () {
   while (true) {
     try {
       yield take(getType(AccountActions.getCafeSessionsRequest))
-      const sessions: Readonly<ICafeSessions> = yield call(cafeSessions)
-      yield put(AccountActions.cafeSessionsSuccess(sessions))
+      const sessions: ICafeSessions = yield call(cafeSessions)
+      const values: ReadonlyArray<ICafeSession> | undefined | null = sessions.values
+      if (!values) {
+        yield put(AccountActions.cafeSessionsSuccess([]))
+      } else {
+        yield put(AccountActions.cafeSessionsSuccess(values))
+      }
     } catch (error) {
       yield put(AccountActions.cafeSessionsError(error))
     }
@@ -78,10 +83,14 @@ export function * refreshCafeSessions () {
     try {
       yield take(getType(AccountActions.refreshCafeSessionsRequest))
       const sessions: Readonly<ICafeSessions> = yield call(cafeSessions)
-      yield put(AccountActions.cafeSessionsSuccess(sessions))
-      // const effects = sessions.map((session) => call(refreshCafeSession, session.id))
-      // const refreshedSessions: ReadonlyArray<CafeSession> = yield all(effects)
-      // yield put(AccountActions.cafeSessionsSuccess(refreshedSessions))
+      const values: ReadonlyArray<ICafeSession> | undefined | null = sessions.values
+      if (!values) {
+        yield put(AccountActions.cafeSessionsSuccess([]))
+      } else {
+        const effects = values.map((session) => call(refreshCafeSession, session.id!))
+        const refreshedValues: ReadonlyArray<ICafeSession> = yield all(effects)
+        yield put(AccountActions.cafeSessionsSuccess(refreshedValues))
+      }
     } catch (error) {
       yield put(AccountActions.cafeSessionsError(error))
     }

--- a/App/Sagas/Account/AccountSagas.ts
+++ b/App/Sagas/Account/AccountSagas.ts
@@ -66,6 +66,9 @@ export function * getCafeSessions () {
     try {
       yield take(getType(AccountActions.getCafeSessionsRequest))
       const sessions: ICafeSessions = yield call(cafeSessions)
+      if (!sessions) {
+        yield put(AccountActions.cafeSessionsSuccess([]))
+      }
       const values: ReadonlyArray<ICafeSession> | undefined | null = sessions.values
       if (!values) {
         yield put(AccountActions.cafeSessionsSuccess([]))
@@ -83,6 +86,9 @@ export function * refreshCafeSessions () {
     try {
       yield take(getType(AccountActions.refreshCafeSessionsRequest))
       const sessions: Readonly<ICafeSessions> = yield call(cafeSessions)
+      if (!sessions) {
+        yield put(AccountActions.cafeSessionsSuccess([]))
+      }
       const values: ReadonlyArray<ICafeSession> | undefined | null = sessions.values
       if (!values) {
         yield put(AccountActions.cafeSessionsSuccess([]))

--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -112,7 +112,7 @@ function * createAndStartNode(dispatch: Dispatch): any {
     yield put(TextileNodeActions.startingNode())
     yield call(start)
     const sessions: ICafeSessions = yield call(cafeSessions)
-    if (!sessions.values || sessions.values.length < 1) {
+    if (!sessions || !sessions.values || sessions.values.length < 1) {
       const cafeOverride: string = Config.RN_TEXTILE_CAFE_OVERRIDE
       if (cafeOverride) {
         yield call(registerOverrideCafe, cafeOverride)

--- a/App/Sagas/NodeLifecycle.ts
+++ b/App/Sagas/NodeLifecycle.ts
@@ -30,9 +30,9 @@ import {
   WalletAccount,
   version,
   registerCafe,
-  cafeSessions,
-  CafeSession
+  cafeSessions
  } from '@textile/react-native-sdk'
+import { ICafeSessions } from '@textile/react-native-protobufs'
 import { logNewEvent } from './DeviceLogs'
 import { announcePeer } from './Migration'
 
@@ -111,8 +111,8 @@ function * createAndStartNode(dispatch: Dispatch): any {
     yield put(TextileNodeActions.createNodeSuccess())
     yield put(TextileNodeActions.startingNode())
     yield call(start)
-    const sessions: ReadonlyArray<CafeSession> = yield call(cafeSessions)
-    if (sessions.length < 1) {
+    const sessions: ICafeSessions = yield call(cafeSessions)
+    if (!sessions.values || sessions.values.length < 1) {
       const cafeOverride: string = Config.RN_TEXTILE_CAFE_OVERRIDE
       if (cafeOverride) {
         yield call(registerOverrideCafe, cafeOverride)

--- a/App/Sagas/UploadFile.ts
+++ b/App/Sagas/UploadFile.ts
@@ -6,16 +6,19 @@ import Config from 'react-native-config'
 
 import AccountActions from '../Redux/AccountRedux'
 import { bestSession } from '../Redux/AccountSelectors'
-import { CafeSession } from '@textile/react-native-sdk'
+import { ICafeSession } from '@textile/react-native-protobufs'
 
 export function * uploadFile (id: string, payloadPath: string) {
-  const session: CafeSession = yield call(getSession)
+  const session: ICafeSession = yield call(getSession)
+  console.log('::::')
+  console.log(session)
+
   yield call(
     Upload.startUpload,
     {
       customUploadId: id,
       path: payloadPath,
-      url: `${session.cafe.url}${Config.RN_TEXTILE_CAFE_API_PIN_PATH}`,
+      url: `${session!.cafe!.url}${Config.RN_TEXTILE_CAFE_API_PIN_PATH}`,
       method: 'POST',
       type: 'raw',
       headers: {
@@ -27,16 +30,16 @@ export function * uploadFile (id: string, payloadPath: string) {
 }
 
 export function * getSession (depth: number = 0): any {
-  const session: CafeSession | undefined = yield select(bestSession)
-  if (!session || new Date(session.exp) < new Date()) {
-    if (depth === 0) {
-      yield put(AccountActions.refreshCafeSessionsRequest())
-      yield take(getType(AccountActions.cafeSessionsSuccess))
-      yield call(getSession, 1)
-    } else {
-      throw new Error('unable to get CafeSession')
-    }
-  } else {
+  const session: ICafeSession | undefined = yield select(bestSession)
+  // if (!session || new Date(session.exp) < new Date()) {
+  //   if (depth === 0) {
+  //     yield put(AccountActions.refreshCafeSessionsRequest())
+  //     yield take(getType(AccountActions.cafeSessionsSuccess))
+  //     yield call(getSession, 1)
+  //   } else {
+  //     throw new Error('unable to get CafeSession')
+  //   }
+  // } else {
     return session
-  }
+  // }
 }

--- a/App/Sagas/UploadFile.ts
+++ b/App/Sagas/UploadFile.ts
@@ -9,13 +9,16 @@ import { bestSession, getSessionMillis } from '../Redux/AccountSelectors'
 import { ICafeSession } from '@textile/react-native-protobufs'
 
 export function * uploadFile (id: string, payloadPath: string) {
-  const session: ICafeSession = yield call(getSession)
+  const session: ICafeSession | undefined = yield call(getSession)
+  if (!session || !session.cafe || !session.cafe.url || !session.access) {
+    return
+  }
   yield call(
     Upload.startUpload,
     {
       customUploadId: id,
       path: payloadPath,
-      url: `${session!.cafe!.url}${Config.RN_TEXTILE_CAFE_API_PIN_PATH}`,
+      url: `${session.cafe.url}${Config.RN_TEXTILE_CAFE_API_PIN_PATH}`,
       method: 'POST',
       type: 'raw',
       headers: {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@textile/react-native-icon": "^1.0.0",
     "@textile/react-native-protobufs": "^1.1.0",
     "@textile/react-native-screen-control": "1.0.12",
-    "@textile/react-native-sdk": "1.0.19",
+    "@textile/react-native-sdk": "1.0.20",
     "@textile/redux-saga-wait-for": "1.0.1",
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@textile/react-native-icon": "^1.0.0",
+    "@textile/react-native-protobufs": "^1.1.0",
     "@textile/react-native-screen-control": "1.0.12",
     "@textile/react-native-sdk": "1.0.19",
     "@textile/redux-saga-wait-for": "1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -641,7 +641,7 @@
   dependencies:
     react-native-vector-icons "^6.2.0"
 
-"@textile/react-native-protobufs@1.1.0":
+"@textile/react-native-protobufs@1.1.0", "@textile/react-native-protobufs@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@textile/react-native-protobufs/-/react-native-protobufs-1.1.0.tgz#facc6791d1e978859ab815fd3208494a5272d675"
   integrity sha512-CsFuXwTxZ1rnWTEOgPeYAIouvmHF0T8Z9Ssoj4JtbG6MgaDbLrwUEOFmSiNYZFPsn0M3QbG8bt6MAypsI/lNLA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,10 +652,10 @@
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/@textile/react-native-screen-control/-/react-native-screen-control-1.0.12.tgz#1be41a4eaa9648fa4766e2489a6c2764d95985e1"
 
-"@textile/react-native-sdk@1.0.19":
-  version "1.0.19"
-  resolved "https://registry.yarnpkg.com/@textile/react-native-sdk/-/react-native-sdk-1.0.19.tgz#f988526007568e1e4de968a98821fe86145643b5"
-  integrity sha512-3zOykLYMhQS4pGleQvstxnxUh819ftGJm1vxXUE220mOdBjopkS7LvbvUDla3sq1/M7nmRbpu/Z0Isv741pcKg==
+"@textile/react-native-sdk@1.0.20":
+  version "1.0.20"
+  resolved "https://registry.yarnpkg.com/@textile/react-native-sdk/-/react-native-sdk-1.0.20.tgz#b9e533090012dbc0da40c694db6e6e36dbfa2783"
+  integrity sha512-yDocomgc2wjrtYeS6WXAGii65V3exJhXIMetube4za2RZerrKFt/UNAgAifsJZD+o6Ez9vnyFHDuydwazvhjaA==
   dependencies:
     "@textile/go-mobile" "1.0.0-rc29"
     "@textile/react-native-protobufs" "1.1.0"


### PR DESCRIPTION
There were a couple issues here:
- `exp` is not a string, it's a proto Timestamp object
- the results from the framework's get / list / refresh session methods can now return an empty byte slice, so the TS api needs to return undefined in that case