### PR TITLE
bump: @textile/react-native-sdk@1.0.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@textile/react-native-icon": "^1.0.0",
     "@textile/react-native-protobufs": "^1.1.0",
     "@textile/react-native-screen-control": "1.0.12",
-    "@textile/react-native-sdk": "1.0.20",
+    "@textile/react-native-sdk": "1.0.21",
     "@textile/redux-saga-wait-for": "1.0.1",
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -630,10 +630,10 @@
     react-native-safe-area-view "^0.11.0"
     react-native-screens "^1.0.0 || ^1.0.0-alpha"
 
-"@textile/go-mobile@1.0.0-rc29":
-  version "1.0.0-rc29"
-  resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-1.0.0-rc29.tgz#cd857120ede7f0b7d5e770fda02fefb327501110"
-  integrity sha512-s+tQRboNlGiyUYTWbq3w5xbb9hzp5fsj3SKt0Xmooz3KX46WtbL9+c5LwuAPy38HKtjdNQsiZiTRTnY/c2+o8w==
+"@textile/go-mobile@1.0.0-rc30":
+  version "1.0.0-rc30"
+  resolved "https://registry.yarnpkg.com/@textile/go-mobile/-/go-mobile-1.0.0-rc30.tgz#3cf46a5de31037a9617ef87bff6e6c7b94c559ae"
+  integrity sha512-zjIQbChIYfub/bverww2fh5wyzr1F0H2P5IMHkIF8dhbYqEHJNoBk9bYE7G/b4VjlyCU3ZV63iHeC+3uB+Rw9A==
 
 "@textile/react-native-icon@^1.0.0":
   version "1.0.0"
@@ -652,12 +652,12 @@
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/@textile/react-native-screen-control/-/react-native-screen-control-1.0.12.tgz#1be41a4eaa9648fa4766e2489a6c2764d95985e1"
 
-"@textile/react-native-sdk@1.0.20":
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/@textile/react-native-sdk/-/react-native-sdk-1.0.20.tgz#b9e533090012dbc0da40c694db6e6e36dbfa2783"
-  integrity sha512-yDocomgc2wjrtYeS6WXAGii65V3exJhXIMetube4za2RZerrKFt/UNAgAifsJZD+o6Ez9vnyFHDuydwazvhjaA==
+"@textile/react-native-sdk@1.0.21":
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/@textile/react-native-sdk/-/react-native-sdk-1.0.21.tgz#951853c37eb98d7a503f855bf9fe1c2aae2fa036"
+  integrity sha512-Fgvy2UzD/aPaz7bMZxCjPqqaJxUQq+nsc9Hm+b1fR6HaJXcHmXkyN4BIV0UtCFBivoUXsF6Zt0nzIESpLBxwzw==
   dependencies:
-    "@textile/go-mobile" "1.0.0-rc29"
+    "@textile/go-mobile" "1.0.0-rc30"
     "@textile/react-native-protobufs" "1.1.0"
     buffer "^5.2.1"
     prop-types "^15.6.2"


### PR DESCRIPTION
Includes https://github.com/raulk/go-libp2p-kad-dht/pull/2.