### PR TITLE
Expose a single event subscription method

### DIFF
--- a/App/Services/EventHandlers/TextileNodeEventHandler.ts
+++ b/App/Services/EventHandlers/TextileNodeEventHandler.ts
@@ -1,10 +1,7 @@
 import { Store } from 'redux'
-import {
-  DeviceEventEmitter
-} from 'react-native'
 
 import { ILocalPhotoResult } from '../../Models/TextileTypes'
-import Textile, { Events, Update, ThreadUpdate, BlockType, NotificationInfo } from '@textile/react-native-sdk'
+import { Events as TextileEvents, Update, ThreadUpdate, BlockType, NotificationInfo } from '@textile/react-native-sdk'
 import { RootState } from '../../Redux/Types'
 
 import NotificationActions from '../../Redux/NotificationsRedux'
@@ -20,6 +17,7 @@ import MigrationActions from '../../Redux/MigrationRedux'
 
 export default class TextileNodeEventHandler {
   store: Store<RootState>
+  events = new TextileEvents()
 
   constructor(store: Store<RootState>) {
     this.store = store
@@ -27,14 +25,14 @@ export default class TextileNodeEventHandler {
   }
 
   setup () {
-    Events.addListener('newLocalPhoto', (localPhoto: ILocalPhotoResult) => {
+    this.events.addListener('newLocalPhoto', (localPhoto: ILocalPhotoResult) => {
       this.store.dispatch(StorageActions.newLocalPhoto(localPhoto))
     })
     // Now handled internally by sdk
-    Events.addListener('onOnline', () => {
+    this.events.addListener('onOnline', () => {
       this.store.dispatch(TextileEventsActions.nodeOnline())
     })
-    Events.addListener('onThreadUpdate', (update: ThreadUpdate) => {
+    this.events.addListener('onThreadUpdate', (update: ThreadUpdate) => {
       const { type } = update.block
       if (type === BlockType.COMMENT ||
         type === BlockType.LIKE ||
@@ -51,62 +49,57 @@ export default class TextileNodeEventHandler {
       const message = `BlockType ${type} on ${name}`
       this.store.dispatch(DeviceLogsActions.logNewEvent( (new Date()).getTime(), 'onThreadUpdate', message, false))
     })
-    Events.addListener('onThreadAdded', (payload: Update) => {
+    this.events.addListener('onThreadAdded', (payload: Update) => {
       this.store.dispatch(PhotoViewingActions.threadAddedNotification(payload.id))
     })
-    Events.addListener('onThreadRemoved', (payload: Update) => {
+    this.events.addListener('onThreadRemoved', (payload: Update) => {
       this.store.dispatch(PhotoViewingActions.threadRemoved(payload.id))
     })
-    Events.addListener('onNotification', (payload: NotificationInfo) => {
+    this.events.addListener('onNotification', (payload: NotificationInfo) => {
       this.store.dispatch(NotificationActions.newNotificationRequest(toTypedNotification(payload)))
     })
-
-    /* ----- JS Events from SDK -----*/
-
-    // New Bridge actions
-
-    DeviceEventEmitter.addListener('@textile/newNodeState', (payload) => {
+    // TextileEventsActions
+    this.events.addListener('newNodeState', (payload) => {
       this.store.dispatch(TextileEventsActions.newNodeState(payload.state))
     })
-    DeviceEventEmitter.addListener('@textile/startNodeFinished', () => {
+    this.events.addListener('startNodeFinished', () => {
       this.store.dispatch(TextileEventsActions.startNodeFinished())
     })
-    DeviceEventEmitter.addListener('@textile/stopNodeAfterDelayStarting', () => {
+    this.events.addListener('stopNodeAfterDelayStarting', () => {
       this.store.dispatch(TextileEventsActions.stopNodeAfterDelayStarting())
     })
-    DeviceEventEmitter.addListener('@textile/stopNodeAfterDelayCancelled', () => {
+    this.events.addListener('stopNodeAfterDelayCancelled', () => {
       this.store.dispatch(TextileEventsActions.stopNodeAfterDelayCancelled())
     })
-    DeviceEventEmitter.addListener('@textile/stopNodeAfterDelayFinishing', () => {
+    this.events.addListener('stopNodeAfterDelayFinishing', () => {
       this.store.dispatch(TextileEventsActions.stopNodeAfterDelayFinishing())
     })
-    DeviceEventEmitter.addListener('@textile/stopNodeAfterDelayComplete', () => {
+    this.events.addListener('stopNodeAfterDelayComplete', () => {
       this.store.dispatch(TextileEventsActions.stopNodeAfterDelayComplete())
     })
-    DeviceEventEmitter.addListener('@textile/appStateChange', (payload) => {
+    this.events.addListener('appStateChange', (payload) => {
       this.store.dispatch(TextileEventsActions.appStateChange(payload.previousState, payload.newState))
     })
-    DeviceEventEmitter.addListener('@textile/updateProfile', () => {
+    this.events.addListener('updateProfile', () => {
       this.store.dispatch(TextileEventsActions.updateProfile())
     })
-    DeviceEventEmitter.addListener('@textile/error', (payload) => {
+    this.events.addListener('error', (payload) => {
       this.store.dispatch(TextileEventsActions.newErrorMessage(payload.type, payload.message))
     })
     // Account actions
-    DeviceEventEmitter.addListener('@textile/setRecoveryPhrase', (payload) => {
+    this.events.addListener('setRecoveryPhrase', (payload) => {
       this.store.dispatch(AccountActions.setRecoveryPhrase(payload.recoveryPhrase))
     })
-    DeviceEventEmitter.addListener('@textile/walletInitSuccess', () => {
+    this.events.addListener('walletInitSuccess', () => {
       this.store.dispatch(AccountActions.initSuccess())
     })
     // Migration actions
-    DeviceEventEmitter.addListener('@textile/migrationNeeded', (payload) => {
+    this.events.addListener('migrationNeeded', (payload) => {
       this.store.dispatch(MigrationActions.migrationNeeded())
     })
   }
 
   tearDown () {
-    Events.removeAllListeners()
-    DeviceEventEmitter.removeAllListeners()
+    this.events.removeAllListeners()
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@textile/react-native-icon": "^1.0.0",
     "@textile/react-native-protobufs": "^1.1.0",
     "@textile/react-native-screen-control": "1.0.12",
-    "@textile/react-native-sdk": "1.1.0-rc10",
+    "@textile/react-native-sdk": "1.1.0-rc13",
     "@textile/redux-saga-wait-for": "1.0.1",
     "moment": "^2.22.2",
     "prop-types": "^15.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,9 +650,9 @@
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/@textile/react-native-screen-control/-/react-native-screen-control-1.0.12.tgz#1be41a4eaa9648fa4766e2489a6c2764d95985e1"
 
-"@textile/react-native-sdk@1.1.0-rc10":
-  version "1.1.0-rc10"
-  resolved "https://registry.yarnpkg.com/@textile/react-native-sdk/-/react-native-sdk-1.1.0-rc10.tgz#9c3cbc6aa66e12fbd7ec51cc0b0b6658c58fb6be"
+"@textile/react-native-sdk@1.1.0-rc13":
+  version "1.1.0-rc13"
+  resolved "https://registry.yarnpkg.com/@textile/react-native-sdk/-/react-native-sdk-1.1.0-rc13.tgz#a7c676ec601b5b0460b2646afb0710607cfd0d76"
   dependencies:
     "@textile/go-mobile" "1.0.0-rc31"
     "@textile/react-native-protobufs" "1.1.0"


### PR DESCRIPTION
Instead of having to make the client mix native and js event subscriptions, I'm just managing within the SDK now and exposing a single interface to add/remove subscriptions. Also helps to create more unique event keys that wont mess with client events while still not making the client have to subscribe to long/ugly keys. 