### PR TITLE
Feed UI crash fix

### DIFF
--- a/App/screens/group/group.tsx
+++ b/App/screens/group/group.tsx
@@ -149,8 +149,8 @@ class Group extends Component<Props, State> {
         return (
           <Photo
             avatar={avatar}
-            username={username || 'unknown'}
-            message={caption}
+            username={username.length > 0 ? username : 'unknown'}
+            message={caption.length > 0 ? caption : undefined}
             time={moment(util.timestampToDate(date)).calendar(undefined, momentSpec)}
             photoId={target}
             fileIndex={files[0].index}


### PR DESCRIPTION
You get the crash if you try to render 0 length text in a `Text` component. If you effectively do this:
```
<Text>{''}</Text>
```
the UI will crash.
 