### PR TITLE
Deep link fix on android

### DIFF
--- a/App/Components/QRCodeModal.tsx
+++ b/App/Components/QRCodeModal.tsx
@@ -60,7 +60,7 @@ class QRCodeModal extends React.Component<DispatchProps & ScreenProps> {
               </View>
               <View style={styles.qrCode}>
                 {this.props.invite && <QRCode
-                  value={this.getLink(this.props.invite.link)}
+                  value={this.props.invite.link}
                   size={240}
                   bgColor='transparent'
                   fgColor='white'

--- a/App/Components/QRCodeModal.tsx
+++ b/App/Components/QRCodeModal.tsx
@@ -6,7 +6,8 @@ import {
   View,
   Text,
   TouchableOpacity,
-  KeyboardAvoidingView
+  KeyboardAvoidingView,
+  Platform
 } from 'react-native'
 import QRCode from 'react-native-qrcode'
 import Modal from 'react-native-modal'
@@ -32,6 +33,10 @@ interface ScreenProps {
 
 class QRCodeModal extends React.Component<DispatchProps & ScreenProps> {
   getLink (link: string): string {
+    if (Platform.OS === 'android') {
+      // issues with Android link getting stolen by chrome... so just going to URL it now
+      return link
+    }
     return link.replace('https://', `${Config.RN_URL_SCHEME}://`)
   }
 

--- a/App/Components/photo.tsx
+++ b/App/Components/photo.tsx
@@ -36,7 +36,7 @@ class Photo extends Component<Props> {
           fileIndex={this.props.fileIndex}
           showPreview={true}
           forMinWidth={this.props.photoWidth}
-          style={{ width: this.props.photoWidth, height: this.props.photoWidth }}
+          style={{ width: this.props.photoWidth, height: this.props.photoWidth, overflow: 'hidden' }}
           resizeMode={'cover'}
         />
         <LikeAndComment {...this.props} />

--- a/App/Containers/OnboardingScreen/index.tsx
+++ b/App/Containers/OnboardingScreen/index.tsx
@@ -83,7 +83,7 @@ class OnboardingScreen extends React.Component<Props, State> {
       })
       setTimeout(() => {
         this.setState({disableNext: false})
-      }, 450)
+      }, 350)
     }
   }
 

--- a/App/Containers/OnboardingScreen/index.tsx
+++ b/App/Containers/OnboardingScreen/index.tsx
@@ -83,7 +83,7 @@ class OnboardingScreen extends React.Component<Props, State> {
       })
       setTimeout(() => {
         this.setState({disableNext: false})
-      }, 750)
+      }, 450)
     }
   }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -35,7 +35,9 @@
           <action android:name="android.intent.action.VIEW" />
           <category android:name="android.intent.category.DEFAULT" />
           <category android:name="android.intent.category.BROWSABLE" />
+          <data android:scheme="textile-beta" android:host="textile.photos"/>
           <data android:scheme="textile-dev" android:host="textile.photos"/>
+          <data android:scheme="textile" android:host="textile.photos"/>
           <data android:scheme="https"
                 android:host="www.textile.photos"
                 android:pathPrefix="/invites" />


### PR DESCRIPTION
seemed to loose the scheme entries

also, chrome on latest android seem to steal the deeplinks from camera, but the links from browser work fine. so just defaulting to link. can't control ios user showing qr to and android scanner, so needs to just go to https that all can use. then in browser you'll get the deep link by clicking 'accept' button