### PR TITLE
Click to content from local notifications in Android

### DIFF
--- a/App/Redux/NotificationsRedux.ts
+++ b/App/Redux/NotificationsRedux.ts
@@ -3,8 +3,8 @@ import {
   Notification,
   InviteReceivedNotification
 } from '../Models/Notifications'
-import { PushNotification } from 'react-native-push-notification'
 import { RootState } from './Types'
+import { PushNotification } from '../Services/EventHandlers/NotificationEventHandler'
 
 const actions = {
   readAllNotificationsRequest: createAction('CLEAR_ALL_NOTIFICATIONS_REQUEST', (resolve) => {

--- a/App/Services/EventHandlers/NotificationEventHandler.ts
+++ b/App/Services/EventHandlers/NotificationEventHandler.ts
@@ -1,9 +1,26 @@
 import { Store } from 'redux'
 import { PushNotificationIOS, Platform } from 'react-native'
-import RNPushNotification, { PushNotification } from 'react-native-push-notification'
+import RNPushNotification from 'react-native-push-notification'
 
 import { RootState } from '../../Redux/Types'
 import NotificationsActions from '../../Redux/NotificationsRedux'
+import { Notification } from '../../Models/Notifications'
+
+export interface UserInfo {
+  notification: Notification
+}
+
+export interface PushNotification {
+  foreground: boolean
+  userInteraction: boolean
+  message: string|object
+  data: object
+  badge: number
+  alert: object
+  sound: string
+  userInfo?: UserInfo
+  finish: (fetchResult: string) => void
+}
 
 export default class NotificationEventHandler {
   store: Store<RootState>
@@ -15,7 +32,11 @@ export default class NotificationEventHandler {
 
   onNotification (notification: PushNotification) {
     if (notification.userInteraction) {
-      this.store.dispatch(NotificationsActions.notificationEngagement(notification))
+      if (notification.userInfo && notification.userInfo.notification) {
+        this.store.dispatch(NotificationsActions.notificationSuccess(notification.userInfo.notification))
+      } else {
+        this.store.dispatch(NotificationsActions.notificationEngagement(notification))
+      }
     }
     if (notification.finish && Platform.OS === 'ios') {
       notification.finish(PushNotificationIOS.FetchResult.NoData)


### PR DESCRIPTION
Bypass the notification lookup stuff if the userinfo payload (just containing the internal notification object) exists